### PR TITLE
perf(ci): optimize CI workflow and fix cache conflicts

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -54,16 +54,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('apps/core/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache-dependency-path: apps/core/go.sum
 
       - name: Download dependencies
         working-directory: apps/core


### PR DESCRIPTION
## Changes

1. **Skip duplicate validation on merge**: Only run validation job during PR, skip on merge to avoid duplicate runs
2. **Fix Go modules cache conflicts**: Replace manual cache step with setup-go built-in caching to eliminate "File exists" errors

## Benefits

- Saves ~5 minutes per merge by skipping redundant validation
- Eliminates cache restoration errors that were cluttering CI logs
- Uses more reliable built-in caching from actions/setup-go@v5

## Testing

- [x] Lefthook pre-push tests passed
- [ ] CI validation will run on this PR