### PR TITLE
chore(core): use direct IP for database connection

### DIFF
--- a/apps/core/configs/config.yaml
+++ b/apps/core/configs/config.yaml
@@ -5,7 +5,7 @@ server:
 
 database:
   driver: "postgres"
-  host: "postgres-host.revieu-prod.svc.cluster.local"
+  host: "10.42.0.1"
   port: 5432
   database: "revieu"
   username: "postgres"


### PR DESCRIPTION
Change database host from Service DNS to direct IP address (10.42.0.1) to avoid complexity with Endpoints/EndpointSlice management.