### PR TITLE
fix(auth): include API base path in OAuth callback URL

### DIFF
--- a/apps/core/internal/handler/routes.go
+++ b/apps/core/internal/handler/routes.go
@@ -10,7 +10,7 @@ import (
 func RegisterRoutes(router *gin.Engine, cfg *config.Config) {
 	// Initialize handlers
 	testHandler := NewTestHandler()
-	authHandler := NewAuthHandler(cfg.JWT, cfg.OAuth, cfg.SMTP, cfg.FrontendURL)
+	authHandler := NewAuthHandler(cfg.JWT, cfg.OAuth, cfg.SMTP, cfg.FrontendURL, cfg.Server.APIBasePath)
 	userHandler := NewUserHandler(nil, nil, nil, nil)
 	profileHandler := NewProfileHandler(nil, nil, nil)
 


### PR DESCRIPTION
Fix OAuth callback URL generation to include the configured API base path (/api/v1). This ensures Google OAuth redirects to the correct URL.

Changes:
- Add apiBasePath field to AuthHandler struct
- Update NewAuthHandler to accept apiBasePath parameter
- Modify GoogleLogin and GoogleCallback to include apiBasePath in redirect URI
- Update routes.go to pass cfg.Server.APIBasePath to NewAuthHandler

Fixes the issue where OAuth callback URL was missing /api/v1 prefix.