### PR TITLE
fix(auth): use X-Forwarded-Proto for HTTPS detection

### DIFF
--- a/apps/core/internal/handler/auth.go
+++ b/apps/core/internal/handler/auth.go
@@ -132,7 +132,10 @@ func (h *AuthHandler) GoogleLogin(c *gin.Context) {
 
 	// Build callback URL
 	scheme := "http"
-	if c.Request.TLS != nil {
+	// Check X-Forwarded-Proto header first (set by reverse proxy/ingress)
+	if proto := c.GetHeader("X-Forwarded-Proto"); proto == "https" {
+		scheme = "https"
+	} else if c.Request.TLS != nil {
 		scheme = "https"
 	}
 	redirectURI := fmt.Sprintf("%s://%s%s/auth/callback/google", scheme, c.Request.Host, h.apiBasePath)
@@ -166,7 +169,10 @@ func (h *AuthHandler) GoogleCallback(c *gin.Context) {
 
 	// Build callback URL (same as in GoogleLogin)
 	scheme := "http"
-	if c.Request.TLS != nil {
+	// Check X-Forwarded-Proto header first (set by reverse proxy/ingress)
+	if proto := c.GetHeader("X-Forwarded-Proto"); proto == "https" {
+		scheme = "https"
+	} else if c.Request.TLS != nil {
 		scheme = "https"
 	}
 	redirectURI := fmt.Sprintf("%s://%s%s/auth/callback/google", scheme, c.Request.Host, h.apiBasePath)


### PR DESCRIPTION
Google OAuth requires HTTPS redirect URIs. When TLS terminates at the ingress (Traefik), c.Request.TLS is nil, so we need to check the X-Forwarded-Proto header to detect the original protocol.

Changes:
- Check X-Forwarded-Proto header first in both GoogleLogin and GoogleCallback
- Fall back to c.Request.TLS check if header not present
- This ensures HTTPS is correctly detected behind reverse proxies

Fixes Google OAuth "redirect_uri_mismatch" error.