### PR TITLE
feat(store): add activation flow and publish visibility gates (#147)

### DIFF
--- a/apps/core/docs/docs.go
+++ b/apps/core/docs/docs.go
@@ -1095,6 +1095,48 @@ const docTemplate = `{
             }
         },
         "/merchant/stores": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns stores owned by the authenticated merchant user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "List current merchant stores",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -1214,6 +1256,170 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/merchant/stores/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Marks a merchant-owned store as published",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "Activate a store",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/merchant/stores/{id}/deactivate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Marks a merchant-owned store as hidden",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "Deactivate a store",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/apps/core/docs/swagger.json
+++ b/apps/core/docs/swagger.json
@@ -1093,6 +1093,48 @@
             }
         },
         "/merchant/stores": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns stores owned by the authenticated merchant user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "List current merchant stores",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -1212,6 +1254,170 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/merchant/stores/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Marks a merchant-owned store as published",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "Activate a store",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/merchant/stores/{id}/deactivate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Marks a merchant-owned store as hidden",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "Deactivate a store",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/apps/core/docs/swagger.yaml
+++ b/apps/core/docs/swagger.yaml
@@ -1252,6 +1252,33 @@ paths:
       tags:
       - media
   /merchant/stores:
+    get:
+      description: Returns stores owned by the authenticated merchant user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List current merchant stores
+      tags:
+      - store
     post:
       consumes:
       - application/json
@@ -1344,6 +1371,112 @@ paths:
       security:
       - BearerAuth: []
       summary: Update a store
+      tags:
+      - store
+  /merchant/stores/{id}/activate:
+    post:
+      description: Marks a merchant-owned store as published
+      parameters:
+      - description: Store ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Activate a store
+      tags:
+      - store
+  /merchant/stores/{id}/deactivate:
+    post:
+      description: Marks a merchant-owned store as hidden
+      parameters:
+      - description: Store ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Deactivate a store
       tags:
       - store
   /merchant/verification:

--- a/apps/core/internal/domain/store/handler/store.go
+++ b/apps/core/internal/domain/store/handler/store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/store/dto"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/store/service"
@@ -30,7 +31,12 @@ func NewStoreHandler(svc *service.StoreService) *StoreHandler {
 // @Failure 500 {object} map[string]string
 // @Router /stores [get]
 func (h *StoreHandler) List(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "not implemented"})
+	stores, err := h.svc.ListPublished(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list stores"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": stores})
 }
 
 // StoreDetail godoc
@@ -44,7 +50,21 @@ func (h *StoreHandler) List(c *gin.Context) {
 // @Failure 404 {object} map[string]string
 // @Router /stores/{id} [get]
 func (h *StoreHandler) Detail(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "not implemented"})
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	store, err := h.svc.DetailPublished(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, service.ErrStoreNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load store"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": store})
 }
 
 // StoreReviews godoc
@@ -58,7 +78,21 @@ func (h *StoreHandler) Detail(c *gin.Context) {
 // @Failure 404 {object} map[string]string
 // @Router /stores/{id}/reviews [get]
 func (h *StoreHandler) Reviews(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "not implemented"})
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	reviews, err := h.svc.ReviewsPublished(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, service.ErrStoreNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load reviews"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": reviews})
 }
 
 // StoreHours godoc
@@ -72,7 +106,45 @@ func (h *StoreHandler) Reviews(c *gin.Context) {
 // @Failure 404 {object} map[string]string
 // @Router /stores/{id}/hours [get]
 func (h *StoreHandler) Hours(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "not implemented"})
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	hours, err := h.svc.HoursPublished(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, service.ErrStoreNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load hours"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": hours})
+}
+
+// ListMerchantStores godoc
+// @Summary List current merchant stores
+// @Description Returns stores owned by the authenticated merchant user
+// @Tags store
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Failure 401 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /merchant/stores [get]
+func (h *StoreHandler) ListMine(c *gin.Context) {
+	userID := c.GetInt64("user_id")
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	stores, err := h.svc.ListMine(c.Request.Context(), userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list stores"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": stores})
 }
 
 // CreateStore godoc
@@ -133,4 +205,82 @@ func (h *StoreHandler) Create(c *gin.Context) {
 // @Router /merchant/stores/{id} [patch]
 func (h *StoreHandler) Update(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "not implemented"})
+}
+
+// ActivateStore godoc
+// @Summary Activate a store
+// @Description Marks a merchant-owned store as published
+// @Tags store
+// @Produce json
+// @Param id path int true "Store ID"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 403 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /merchant/stores/{id}/activate [post]
+func (h *StoreHandler) Activate(c *gin.Context) {
+	userID := c.GetInt64("user_id")
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	storeID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	if err := h.svc.Activate(c.Request.Context(), userID, storeID); err != nil {
+		switch {
+		case errors.Is(err, service.ErrStoreNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		case errors.Is(err, service.ErrStoreForbidden):
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to activate store"})
+		}
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// DeactivateStore godoc
+// @Summary Deactivate a store
+// @Description Marks a merchant-owned store as hidden
+// @Tags store
+// @Produce json
+// @Param id path int true "Store ID"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 403 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /merchant/stores/{id}/deactivate [post]
+func (h *StoreHandler) Deactivate(c *gin.Context) {
+	userID := c.GetInt64("user_id")
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	storeID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	if err := h.svc.Deactivate(c.Request.Context(), userID, storeID); err != nil {
+		switch {
+		case errors.Is(err, service.ErrStoreNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		case errors.Is(err, service.ErrStoreForbidden):
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to deactivate store"})
+		}
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }

--- a/apps/core/internal/domain/store/routes.go
+++ b/apps/core/internal/domain/store/routes.go
@@ -23,7 +23,10 @@ func RegisterRoutes(r *gin.RouterGroup, cfg *config.Config) {
 
 	merchantStores := r.Group("/merchant/stores", middleware.JWTAuth(cfg.JWT))
 	{
+		merchantStores.GET("", h.ListMine)
 		merchantStores.POST("", h.Create)
+		merchantStores.POST("/:id/activate", h.Activate)
+		merchantStores.POST("/:id/deactivate", h.Deactivate)
 		merchantStores.PATCH("/:id", h.Update)
 	}
 }

--- a/apps/core/internal/domain/store/service/service.go
+++ b/apps/core/internal/domain/store/service/service.go
@@ -17,7 +17,17 @@ type StoreService struct {
 	db *gorm.DB
 }
 
-var ErrUserNotFound = errors.New("user not found")
+const (
+	StoreStatusDraft     int16 = 0
+	StoreStatusPublished int16 = 1
+	StoreStatusHidden    int16 = 2
+)
+
+var (
+	ErrUserNotFound   = errors.New("user not found")
+	ErrStoreNotFound  = errors.New("store not found")
+	ErrStoreForbidden = errors.New("store forbidden")
+)
 
 func NewStoreService(db *gorm.DB) *StoreService {
 	if db == nil {
@@ -81,6 +91,7 @@ func (s *StoreService) Create(ctx context.Context, userID int64, req dto.CreateS
 		Longitude:     req.Longitude,
 		CoverImageURL: req.CoverImageURL,
 		Images:        string(imagesRaw),
+		Status:        StoreStatusDraft,
 	}
 
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -111,4 +122,105 @@ func (s *StoreService) Create(ctx context.Context, userID int64, req dto.CreateS
 	}
 
 	return &store, nil
+}
+
+func (s *StoreService) ListPublished(ctx context.Context) ([]model.Store, error) {
+	var stores []model.Store
+	if err := s.db.WithContext(ctx).
+		Where("status = ?", StoreStatusPublished).
+		Order("id desc").
+		Find(&stores).Error; err != nil {
+		return nil, err
+	}
+	return stores, nil
+}
+
+func (s *StoreService) DetailPublished(ctx context.Context, storeID int64) (*model.Store, error) {
+	var store model.Store
+	if err := s.db.WithContext(ctx).
+		Where("id = ? AND status = ?", storeID, StoreStatusPublished).
+		First(&store).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrStoreNotFound
+		}
+		return nil, err
+	}
+	return &store, nil
+}
+
+func (s *StoreService) ReviewsPublished(ctx context.Context, storeID int64) ([]model.Review, error) {
+	if _, err := s.DetailPublished(ctx, storeID); err != nil {
+		return nil, err
+	}
+	var reviews []model.Review
+	if err := s.db.WithContext(ctx).
+		Where("store_id = ?", storeID).
+		Order("id desc").
+		Find(&reviews).Error; err != nil {
+		return nil, err
+	}
+	return reviews, nil
+}
+
+func (s *StoreService) HoursPublished(ctx context.Context, storeID int64) ([]model.StoreHour, error) {
+	if _, err := s.DetailPublished(ctx, storeID); err != nil {
+		return nil, err
+	}
+	var hours []model.StoreHour
+	if err := s.db.WithContext(ctx).
+		Where("store_id = ?", storeID).
+		Order("day_of_week asc").
+		Find(&hours).Error; err != nil {
+		return nil, err
+	}
+	return hours, nil
+}
+
+func (s *StoreService) ListMine(ctx context.Context, userID int64) ([]model.Store, error) {
+	var stores []model.Store
+	if err := s.db.WithContext(ctx).
+		Model(&model.Store{}).
+		Joins("JOIN merchants ON merchants.id = stores.merchant_id").
+		Where("merchants.user_id = ?", userID).
+		Order("stores.id desc").
+		Find(&stores).Error; err != nil {
+		return nil, err
+	}
+	return stores, nil
+}
+
+func (s *StoreService) Activate(ctx context.Context, userID, storeID int64) error {
+	return s.updateStatusOwned(ctx, userID, storeID, StoreStatusPublished)
+}
+
+func (s *StoreService) Deactivate(ctx context.Context, userID, storeID int64) error {
+	return s.updateStatusOwned(ctx, userID, storeID, StoreStatusHidden)
+}
+
+func (s *StoreService) updateStatusOwned(ctx context.Context, userID, storeID int64, toStatus int16) error {
+	var merchant model.Merchant
+	if err := s.db.WithContext(ctx).Where("user_id = ?", userID).First(&merchant).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrStoreForbidden
+		}
+		return err
+	}
+
+	var store model.Store
+	if err := s.db.WithContext(ctx).First(&store, storeID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrStoreNotFound
+		}
+		return err
+	}
+	if store.MerchantID != merchant.ID {
+		return ErrStoreForbidden
+	}
+	if store.Status == toStatus {
+		return nil
+	}
+	return s.db.WithContext(ctx).
+		Model(&model.Store{}).
+		Where("id = ?", storeID).
+		UpdateColumn("status", toStatus).Error
 }

--- a/apps/core/internal/domain/store/service/service_test.go
+++ b/apps/core/internal/domain/store/service/service_test.go
@@ -68,6 +68,9 @@ func TestStoreServiceCreate(t *testing.T) {
 	if store.MerchantID != merchant.ID {
 		t.Fatalf("unexpected merchant id: got %d, want %d", store.MerchantID, merchant.ID)
 	}
+	if store.Status != StoreStatusDraft {
+		t.Fatalf("unexpected store status: got %d, want %d", store.Status, StoreStatusDraft)
+	}
 	if store.Images != "[\"https://img.example/1.jpg\",\"https://img.example/2.jpg\"]" {
 		t.Fatalf("unexpected images json: %s", store.Images)
 	}
@@ -159,5 +162,162 @@ func TestStoreServiceCreateUserNotFound(t *testing.T) {
 	_, err := svc.Create(context.Background(), 9999, dto.CreateStoreRequest{Name: "Missing User"})
 	if !errors.Is(err, ErrUserNotFound) {
 		t.Fatalf("expected ErrUserNotFound, got %v", err)
+	}
+}
+
+func TestStoreServiceActivateOwnStore(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	userID := int64(1001)
+	if err := db.Create(&model.User{ID: userID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &userID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Draft Store", Status: StoreStatusDraft}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	if err := svc.Activate(context.Background(), userID, store.ID); err != nil {
+		t.Fatalf("activate returned error: %v", err)
+	}
+
+	var refreshed model.Store
+	if err := db.First(&refreshed, store.ID).Error; err != nil {
+		t.Fatalf("failed to reload store: %v", err)
+	}
+	if refreshed.Status != StoreStatusPublished {
+		t.Fatalf("unexpected status after activation: got %d, want %d", refreshed.Status, StoreStatusPublished)
+	}
+}
+
+func TestStoreServiceActivateNonOwnerForbidden(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	ownerID := int64(2001)
+	otherID := int64(2002)
+	for _, id := range []int64{ownerID, otherID} {
+		if err := db.Create(&model.User{ID: id, Role: "user", Status: 0}).Error; err != nil {
+			t.Fatalf("failed to create user %d: %v", id, err)
+		}
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &ownerID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Draft Store", Status: StoreStatusDraft}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	err := svc.Activate(context.Background(), otherID, store.ID)
+	if !errors.Is(err, ErrStoreForbidden) {
+		t.Fatalf("expected ErrStoreForbidden, got %v", err)
+	}
+}
+
+func TestStoreServiceDeactivateOwnStore(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	userID := int64(3001)
+	if err := db.Create(&model.User{ID: userID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &userID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Published Store", Status: StoreStatusPublished}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	if err := svc.Deactivate(context.Background(), userID, store.ID); err != nil {
+		t.Fatalf("deactivate returned error: %v", err)
+	}
+
+	var refreshed model.Store
+	if err := db.First(&refreshed, store.ID).Error; err != nil {
+		t.Fatalf("failed to reload store: %v", err)
+	}
+	if refreshed.Status != StoreStatusHidden {
+		t.Fatalf("unexpected status after deactivation: got %d, want %d", refreshed.Status, StoreStatusHidden)
+	}
+}
+
+func TestStoreServiceListPublished(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	merchant := model.Merchant{Name: "Demo"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	draft := model.Store{MerchantID: merchant.ID, Name: "Draft", Status: StoreStatusDraft}
+	published := model.Store{MerchantID: merchant.ID, Name: "Published", Status: StoreStatusPublished}
+	if err := db.Create(&draft).Error; err != nil {
+		t.Fatalf("failed to create draft store: %v", err)
+	}
+	if err := db.Create(&published).Error; err != nil {
+		t.Fatalf("failed to create published store: %v", err)
+	}
+
+	stores, err := svc.ListPublished(context.Background())
+	if err != nil {
+		t.Fatalf("list published returned error: %v", err)
+	}
+	if len(stores) != 1 {
+		t.Fatalf("unexpected published stores count: got %d, want 1", len(stores))
+	}
+	if stores[0].ID != published.ID {
+		t.Fatalf("unexpected published store id: got %d, want %d", stores[0].ID, published.ID)
+	}
+}
+
+func TestStoreServiceListMine(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	userID := int64(4001)
+	otherID := int64(4002)
+	for _, id := range []int64{userID, otherID} {
+		if err := db.Create(&model.User{ID: id, Role: "user", Status: 0}).Error; err != nil {
+			t.Fatalf("failed to create user %d: %v", id, err)
+		}
+	}
+
+	myMerchant := model.Merchant{Name: "Mine", UserID: &userID}
+	otherMerchant := model.Merchant{Name: "Other", UserID: &otherID}
+	if err := db.Create(&myMerchant).Error; err != nil {
+		t.Fatalf("failed to create my merchant: %v", err)
+	}
+	if err := db.Create(&otherMerchant).Error; err != nil {
+		t.Fatalf("failed to create other merchant: %v", err)
+	}
+
+	myStore := model.Store{MerchantID: myMerchant.ID, Name: "My Store", Status: StoreStatusDraft}
+	otherStore := model.Store{MerchantID: otherMerchant.ID, Name: "Other Store", Status: StoreStatusPublished}
+	if err := db.Create(&myStore).Error; err != nil {
+		t.Fatalf("failed to create my store: %v", err)
+	}
+	if err := db.Create(&otherStore).Error; err != nil {
+		t.Fatalf("failed to create other store: %v", err)
+	}
+
+	stores, err := svc.ListMine(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("list mine returned error: %v", err)
+	}
+	if len(stores) != 1 {
+		t.Fatalf("unexpected mine stores count: got %d, want 1", len(stores))
+	}
+	if stores[0].ID != myStore.ID {
+		t.Fatalf("unexpected mine store id: got %d, want %d", stores[0].ID, myStore.ID)
 	}
 }

--- a/apps/core/internal/router/openapi_v1_test.go
+++ b/apps/core/internal/router/openapi_v1_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const testJWTSecret = "test-secret"
+
 func setupAPITest(t *testing.T) (*gin.Engine, string) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -24,7 +27,7 @@ func setupAPITest(t *testing.T) (*gin.Engine, string) {
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{APIBasePath: "/api/v1"},
-		JWT:    config.JWTConfig{Secret: "test-secret", ExpireHour: 24},
+		JWT:    config.JWTConfig{Secret: testJWTSecret, ExpireHour: 24},
 	}
 
 	r := gin.New()
@@ -37,6 +40,19 @@ func setupAPITest(t *testing.T) (*gin.Engine, string) {
 	tok, _ := token.New(cfg.JWT).GenerateToken(&user, &auth)
 
 	return r, tok
+}
+
+func issueAPITestToken(t *testing.T, user model.User, email string) string {
+	t.Helper()
+	auth := model.UserAuth{UserID: user.ID, IdentityType: "email", Identifier: email}
+	if err := database.DB.Create(&auth).Error; err != nil {
+		t.Fatalf("failed to create auth: %v", err)
+	}
+	tok, err := token.New(config.JWTConfig{Secret: testJWTSecret, ExpireHour: 24}).GenerateToken(&user, &auth)
+	if err != nil {
+		t.Fatalf("failed to issue token: %v", err)
+	}
+	return tok
 }
 
 func TestFeedHome(t *testing.T) {
@@ -97,6 +113,120 @@ func TestMerchantReviews(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestStoreCreateActivateAndPublicVisibility(t *testing.T) {
+	r, tok := setupAPITest(t)
+
+	createBody := strings.NewReader(`{"name":"Draft Store","address":"Austin"}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/merchant/stores", createBody)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected create 201, got %d", w.Code)
+	}
+
+	var created struct {
+		Data model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+	if created.Data.Status != 0 {
+		t.Fatalf("expected created store status 0(draft), got %d", created.Data.Status)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/api/v1/stores", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected list 200, got %d", w.Code)
+	}
+	var listed struct {
+		Data []model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("failed to decode stores list response: %v", err)
+	}
+	if len(listed.Data) != 0 {
+		t.Fatalf("expected no public stores before activation, got %d", len(listed.Data))
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/merchant/stores/%d/activate", created.Data.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected activate 200, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/api/v1/stores", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected list 200 after activate, got %d", w.Code)
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("failed to decode stores list response after activate: %v", err)
+	}
+	if len(listed.Data) != 1 {
+		t.Fatalf("expected one public store after activation, got %d", len(listed.Data))
+	}
+	if listed.Data[0].ID != created.Data.ID {
+		t.Fatalf("unexpected public store id: got %d, want %d", listed.Data[0].ID, created.Data.ID)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/merchant/stores/%d/deactivate", created.Data.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected deactivate 200, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/stores/%d", created.Data.ID), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected detail 404 after deactivate, got %d", w.Code)
+	}
+}
+
+func TestStoreActivateForbiddenForNonOwner(t *testing.T) {
+	r, ownerToken := setupAPITest(t)
+
+	createBody := strings.NewReader(`{"name":"Owner Store","address":"Austin"}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/merchant/stores", createBody)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected create 201, got %d", w.Code)
+	}
+	var created struct {
+		Data model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+
+	db := database.DB
+	other := model.User{Role: "user", Status: 0}
+	if err := db.Create(&other).Error; err != nil {
+		t.Fatalf("failed to create other user: %v", err)
+	}
+	otherToken := issueAPITestToken(t, other, "other@example.com")
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/merchant/stores/%d/activate", created.Data.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+otherToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected forbidden activate for non-owner, got %d", w.Code)
 	}
 }
 

--- a/apps/core/internal/testutil/db.go
+++ b/apps/core/internal/testutil/db.go
@@ -24,6 +24,8 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 		&model.EmailVerification{},
 		&model.RefreshToken{},
 		&model.Merchant{},
+		&model.Store{},
+		&model.StoreHour{},
 		&model.Tag{},
 		&model.Post{},
 		&model.Review{},


### PR DESCRIPTION
## Summary
- Add store rollout status model (`draft`, `published`, `hidden`) and set newly created stores to `draft`.
- Add owner-only activation lifecycle endpoints: `POST /merchant/stores/{id}/activate` and `POST /merchant/stores/{id}/deactivate`.
- Enforce public visibility gate so public store reads only return `published` stores; add merchant-owned store listing endpoint and refresh Swagger docs.

## Test Plan
- [x] `GOCACHE=/tmp/go-build go test ./...` (in `apps/core`)
- [x] Verified live API flow against DB `10.0.0.1`: create (hidden) -> activate (public) -> deactivate (hidden)

Closes #147
