### PR TITLE
fix(auth): fail fast when JWT_SECRET is empty (#150)

### DIFF
--- a/apps/core/internal/config/config.go
+++ b/apps/core/internal/config/config.go
@@ -158,5 +158,9 @@ func Load() (*Config, error) {
 		cfg.R2.PublicURL = os.Getenv(envVar)
 	}
 
+	if strings.TrimSpace(cfg.JWT.Secret) == "" {
+		return nil, fmt.Errorf("jwt.secret is empty: set JWT_SECRET before starting server")
+	}
+
 	return &cfg, nil
 }

--- a/apps/core/internal/config/config_test.go
+++ b/apps/core/internal/config/config_test.go
@@ -178,6 +178,53 @@ server:
 	}
 }
 
+func TestLoad_JWTSecretMissingFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+server:
+  address: ":8080"
+  port: 8080
+  mode: "debug"
+
+database:
+  driver: "postgres"
+  host: "localhost"
+  port: 5432
+  database: "testdb"
+  username: "testuser"
+  password: "testpass"
+
+logger:
+  level: "info"
+  format: "json"
+
+jwt:
+  secret: "${JWT_SECRET}"
+  expire_hour: 24
+
+oauth:
+  google:
+    client_id: "test-client-id"
+    client_secret: "test-client-secret"
+
+frontend_url: "http://localhost:3000"
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+
+	os.Setenv("CONFIG_PATH", configPath)
+	os.Unsetenv("JWT_SECRET")
+	defer os.Unsetenv("CONFIG_PATH")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() expected error when JWT_SECRET is empty, got nil")
+	}
+}
+
 func TestLoad_RefreshExpireHour(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")


### PR DESCRIPTION
- validate JWT secret during config load and abort startup when empty
- add regression test for missing JWT_SECRET env resolution

Closes #150