### PR TITLE
fix(review): enforce store binding validation and detail consistency (#153)

### DIFF
--- a/apps/core/docs/docs.go
+++ b/apps/core/docs/docs.go
@@ -2019,6 +2019,24 @@ const docTemplate = `{
                                 "type": "string"
                             }
                         }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }

--- a/apps/core/docs/swagger.json
+++ b/apps/core/docs/swagger.json
@@ -2017,6 +2017,24 @@
                                 "type": "string"
                             }
                         }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }

--- a/apps/core/docs/swagger.yaml
+++ b/apps/core/docs/swagger.yaml
@@ -1907,6 +1907,18 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "422":
+          description: Unprocessable Entity
+          schema:
+            additionalProperties:
+              type: string
+            type: object
       summary: Create a review
       tags:
       - review

--- a/apps/core/internal/domain/review/handler/review.go
+++ b/apps/core/internal/domain/review/handler/review.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -49,6 +50,8 @@ func (h *ReviewHandler) ListMyReviews(c *gin.Context) {
 // @Success 201 {object} dto.Review
 // @Failure 400 {object} map[string]string
 // @Failure 401 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 422 {object} map[string]string
 // @Router /reviews [post]
 func (h *ReviewHandler) Create(c *gin.Context) {
 	userID := c.GetInt64("user_id")
@@ -59,7 +62,14 @@ func (h *ReviewHandler) Create(c *gin.Context) {
 	}
 	created, err := h.svc.Create(c.Request.Context(), userID, req)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		switch {
+		case errors.Is(err, service.ErrMerchantNotFound), errors.Is(err, service.ErrStoreNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		case errors.Is(err, service.ErrStoreMerchantMismatch):
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
 		return
 	}
 	c.JSON(http.StatusCreated, dto.FromModel(created))

--- a/apps/core/internal/domain/review/service/service.go
+++ b/apps/core/internal/domain/review/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/review/dto"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
@@ -13,6 +14,10 @@ import (
 type ReviewService struct {
 	db *gorm.DB
 }
+
+var ErrMerchantNotFound = errors.New("merchant not found")
+var ErrStoreNotFound = errors.New("store not found")
+var ErrStoreMerchantMismatch = errors.New("store does not belong to merchant")
 
 func NewReviewService(db *gorm.DB) *ReviewService {
 	if db == nil {
@@ -31,7 +36,7 @@ func (s *ReviewService) ListByUser(ctx context.Context, userID int64) ([]model.R
 
 func (s *ReviewService) Detail(ctx context.Context, id int64) (*model.Review, error) {
 	var review model.Review
-	if err := s.db.WithContext(ctx).First(&review, id).Error; err != nil {
+	if err := s.db.WithContext(ctx).Preload("Merchant").Preload("Store").First(&review, id).Error; err != nil {
 		return nil, err
 	}
 	return &review, nil
@@ -42,6 +47,15 @@ func (s *ReviewService) Create(ctx context.Context, userID int64, req dto.Review
 	if err != nil {
 		return model.Review{}, err
 	}
+
+	var merchant model.Merchant
+	if err := s.db.WithContext(ctx).Select("id").First(&merchant, merchantID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return model.Review{}, ErrMerchantNotFound
+		}
+		return model.Review{}, err
+	}
+
 	venueID := merchantID
 	if req.VenueID != "" {
 		venueID, err = req.VenueIDValue()
@@ -52,6 +66,18 @@ func (s *ReviewService) Create(ctx context.Context, userID int64, req dto.Review
 	storeID, err := req.StoreIDValue()
 	if err != nil {
 		return model.Review{}, err
+	}
+	if storeID != nil {
+		var store model.Store
+		if err := s.db.WithContext(ctx).Select("id", "merchant_id").First(&store, *storeID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return model.Review{}, ErrStoreNotFound
+			}
+			return model.Review{}, err
+		}
+		if store.MerchantID != merchantID {
+			return model.Review{}, ErrStoreMerchantMismatch
+		}
 	}
 	visitDate, err := req.VisitDateValue()
 	if err != nil {

--- a/apps/core/internal/domain/review/service/service_test.go
+++ b/apps/core/internal/domain/review/service/service_test.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/review/dto"
+	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
+	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/testutil"
+	"gorm.io/gorm"
+)
+
+func setupReviewServiceTest(t *testing.T) (*ReviewService, *gorm.DB, int64) {
+	t.Helper()
+
+	db := testutil.SetupTestDB(t)
+	svc := NewReviewService(db)
+
+	user := model.User{Role: "user", Status: 0}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	return svc, db, user.ID
+}
+
+func TestCreateReviewMerchantMustExist(t *testing.T) {
+	svc, _, userID := setupReviewServiceTest(t)
+
+	_, err := svc.Create(context.Background(), userID, dto.Review{
+		MerchantID: "99999",
+		Rating:     4.5,
+		Text:       "great",
+	})
+	if err == nil || err.Error() != "merchant not found" {
+		t.Fatalf("expected merchant not found, got %v", err)
+	}
+}
+
+func TestCreateReviewStoreMustExist(t *testing.T) {
+	svc, db, userID := setupReviewServiceTest(t)
+
+	merchant := model.Merchant{Name: "Cafe"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+
+	_, err := svc.Create(context.Background(), userID, dto.Review{
+		MerchantID: fmt.Sprintf("%d", merchant.ID),
+		StoreID:    "99999",
+		Rating:     4.5,
+		Text:       "great",
+	})
+	if err == nil || err.Error() != "store not found" {
+		t.Fatalf("expected store not found, got %v", err)
+	}
+}
+
+func TestCreateReviewStoreMustBelongToMerchant(t *testing.T) {
+	svc, db, userID := setupReviewServiceTest(t)
+
+	merchantA := model.Merchant{Name: "A"}
+	if err := db.Create(&merchantA).Error; err != nil {
+		t.Fatalf("failed to create merchantA: %v", err)
+	}
+	merchantB := model.Merchant{Name: "B"}
+	if err := db.Create(&merchantB).Error; err != nil {
+		t.Fatalf("failed to create merchantB: %v", err)
+	}
+
+	store := model.Store{MerchantID: merchantB.ID, Name: "B-Store"}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	_, err := svc.Create(context.Background(), userID, dto.Review{
+		MerchantID: fmt.Sprintf("%d", merchantA.ID),
+		StoreID:    fmt.Sprintf("%d", store.ID),
+		Rating:     4.5,
+		Text:       "great",
+	})
+	if err == nil || err.Error() != "store does not belong to merchant" {
+		t.Fatalf("expected store ownership error, got %v", err)
+	}
+}
+
+func TestReviewDetailPreloadsMerchantAndStore(t *testing.T) {
+	svc, db, userID := setupReviewServiceTest(t)
+
+	merchant := model.Merchant{Name: "Cafe", BusinessName: "Cafe Business", Address: "SF"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+
+	store := model.Store{MerchantID: merchant.ID, Name: "Downtown"}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	storeID := store.ID
+	review := model.Review{
+		UserID:     userID,
+		VenueID:    merchant.ID,
+		MerchantID: merchant.ID,
+		StoreID:    &storeID,
+		Rating:     5,
+		Content:    "nice",
+		VisitDate:  time.Now(),
+	}
+	if err := db.Create(&review).Error; err != nil {
+		t.Fatalf("failed to create review: %v", err)
+	}
+
+	got, err := svc.Detail(context.Background(), review.ID)
+	if err != nil {
+		t.Fatalf("detail failed: %v", err)
+	}
+	if got.Merchant == nil {
+		t.Fatalf("expected merchant preloaded")
+	}
+	if got.Store == nil {
+		t.Fatalf("expected store preloaded")
+	}
+}

--- a/apps/core/internal/router/openapi_v1_test.go
+++ b/apps/core/internal/router/openapi_v1_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -136,6 +137,108 @@ func TestReviewsCreateAndDetail(t *testing.T) {
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d", w.Code)
+	}
+}
+
+func TestReviewsCreateReturnsNotFoundWhenMerchantMissing(t *testing.T) {
+	r, tok := setupAPITest(t)
+
+	body := strings.NewReader(`{"merchantId":"99999","rating":4.5,"text":"nice"}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/reviews", body)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestReviewsCreateReturnsNotFoundWhenStoreMissing(t *testing.T) {
+	r, tok := setupAPITest(t)
+	db := database.DB
+
+	merchant := model.Merchant{Name: "Cafe"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+
+	body := strings.NewReader(fmt.Sprintf(`{"merchantId":"%d","storeId":"99999","rating":4.5,"text":"nice"}`, merchant.ID))
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/reviews", body)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestReviewsCreateReturnsUnprocessableWhenStoreMerchantMismatch(t *testing.T) {
+	r, tok := setupAPITest(t)
+	db := database.DB
+
+	merchantA := model.Merchant{Name: "A"}
+	if err := db.Create(&merchantA).Error; err != nil {
+		t.Fatalf("failed to create merchantA: %v", err)
+	}
+	merchantB := model.Merchant{Name: "B"}
+	if err := db.Create(&merchantB).Error; err != nil {
+		t.Fatalf("failed to create merchantB: %v", err)
+	}
+	store := model.Store{MerchantID: merchantB.ID, Name: "B-Store"}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	body := strings.NewReader(fmt.Sprintf(`{"merchantId":"%d","storeId":"%d","rating":4.5,"text":"nice"}`, merchantA.ID, store.ID))
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/reviews", body)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", w.Code)
+	}
+}
+
+func TestReviewDetailIncludesMerchantFields(t *testing.T) {
+	r, _ := setupAPITest(t)
+	db := database.DB
+
+	u := model.User{Role: "user", Status: 0}
+	if err := db.Create(&u).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	m := model.Merchant{Name: "Cafe", BusinessName: "Cafe Business", Address: "San Francisco"}
+	if err := db.Create(&m).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	review := model.Review{UserID: u.ID, MerchantID: m.ID, VenueID: m.ID, Rating: 4.5, Content: "ok"}
+	if err := db.Create(&review).Error; err != nil {
+		t.Fatalf("failed to create review: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/reviews/%d", review.ID), nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["businessName"] != "Cafe Business" {
+		t.Fatalf("expected businessName Cafe Business, got %v", resp["businessName"])
+	}
+	if resp["location"] != "San Francisco" {
+		t.Fatalf("expected location San Francisco, got %v", resp["location"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- enforce domain validation for `POST /api/v1/reviews`:
  - merchant must exist
  - store must exist when provided
  - store must belong to merchant
- return explicit status codes for validation failures:
  - `404` for missing merchant/store
  - `422` for store-merchant mismatch
- preload `Merchant` and `Store` in review detail query for stable response fields
- update Swagger docs for the new `POST /reviews` error contract

## Changes
- `apps/core/internal/domain/review/service/service.go`
- `apps/core/internal/domain/review/handler/review.go`
- `apps/core/internal/domain/review/service/service_test.go`
- `apps/core/internal/router/openapi_v1_test.go`
- `apps/core/docs/docs.go`
- `apps/core/docs/swagger.json`
- `apps/core/docs/swagger.yaml`

## Verification
### Automated
- `cd apps/core && GOCACHE=/tmp/go-build go test ./...`
- `cd apps/core && make swagger`

### Local API (localhost)
- `GET /api/v1/health` -> `200`
- `POST /api/v1/auth/login` -> `200`
- `POST /api/v1/merchant/stores` -> `201`
- `POST /api/v1/reviews` (valid merchant+store) -> `201`
- `POST /api/v1/reviews` (missing merchant) -> `404`
- `POST /api/v1/reviews` (missing store) -> `404`
- `POST /api/v1/reviews` (store-merchant mismatch) -> `422`
- `GET /api/v1/reviews/{id}` -> `200`

Closes #153
