### PR TITLE
feat(store): restore activation baseline and detail associations (#147)

### DIFF
--- a/apps/core/docs/docs.go
+++ b/apps/core/docs/docs.go
@@ -1095,6 +1095,48 @@ const docTemplate = `{
             }
         },
         "/merchant/stores": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns stores owned by the authenticated merchant user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "List current merchant stores",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -1201,6 +1243,170 @@ const docTemplate = `{
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/merchant/stores/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Marks a merchant-owned store as published",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "Activate a store",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/merchant/stores/{id}/deactivate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Marks a merchant-owned store as hidden",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "Deactivate a store",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {

--- a/apps/core/docs/swagger.json
+++ b/apps/core/docs/swagger.json
@@ -1093,6 +1093,48 @@
             }
         },
         "/merchant/stores": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns stores owned by the authenticated merchant user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "List current merchant stores",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -1199,6 +1241,170 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/merchant/stores/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Marks a merchant-owned store as published",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "Activate a store",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/merchant/stores/{id}/deactivate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Marks a merchant-owned store as hidden",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "Deactivate a store",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {

--- a/apps/core/docs/swagger.yaml
+++ b/apps/core/docs/swagger.yaml
@@ -1297,6 +1297,33 @@ paths:
       tags:
       - media
   /merchant/stores:
+    get:
+      description: Returns stores owned by the authenticated merchant user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List current merchant stores
+      tags:
+      - store
     post:
       consumes:
       - application/json
@@ -1395,6 +1422,112 @@ paths:
       security:
       - BearerAuth: []
       summary: Update a store
+      tags:
+      - store
+  /merchant/stores/{id}/activate:
+    post:
+      description: Marks a merchant-owned store as published
+      parameters:
+      - description: Store ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Activate a store
+      tags:
+      - store
+  /merchant/stores/{id}/deactivate:
+    post:
+      description: Marks a merchant-owned store as hidden
+      parameters:
+      - description: Store ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Deactivate a store
       tags:
       - store
   /merchant/verification:

--- a/apps/core/internal/domain/store/handler/store.go
+++ b/apps/core/internal/domain/store/handler/store.go
@@ -31,7 +31,12 @@ func NewStoreHandler(svc *service.StoreService) *StoreHandler {
 // @Failure 500 {object} map[string]string
 // @Router /stores [get]
 func (h *StoreHandler) List(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "not implemented"})
+	stores, err := h.svc.ListPublished(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list stores"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": stores})
 }
 
 // StoreDetail godoc
@@ -45,7 +50,21 @@ func (h *StoreHandler) List(c *gin.Context) {
 // @Failure 404 {object} map[string]string
 // @Router /stores/{id} [get]
 func (h *StoreHandler) Detail(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "not implemented"})
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	store, err := h.svc.DetailPublished(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, service.ErrStoreNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load store"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": store})
 }
 
 // StoreReviews godoc
@@ -59,7 +78,21 @@ func (h *StoreHandler) Detail(c *gin.Context) {
 // @Failure 404 {object} map[string]string
 // @Router /stores/{id}/reviews [get]
 func (h *StoreHandler) Reviews(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "not implemented"})
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	reviews, err := h.svc.ReviewsPublished(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, service.ErrStoreNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load reviews"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": reviews})
 }
 
 // StoreHours godoc
@@ -73,7 +106,45 @@ func (h *StoreHandler) Reviews(c *gin.Context) {
 // @Failure 404 {object} map[string]string
 // @Router /stores/{id}/hours [get]
 func (h *StoreHandler) Hours(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "not implemented"})
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	hours, err := h.svc.HoursPublished(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, service.ErrStoreNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load hours"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": hours})
+}
+
+// ListMerchantStores godoc
+// @Summary List current merchant stores
+// @Description Returns stores owned by the authenticated merchant user
+// @Tags store
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Failure 401 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /merchant/stores [get]
+func (h *StoreHandler) ListMine(c *gin.Context) {
+	userID := c.GetInt64("user_id")
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	stores, err := h.svc.ListMine(c.Request.Context(), userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list stores"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": stores})
 }
 
 // CreateStore godoc
@@ -168,4 +239,82 @@ func (h *StoreHandler) Update(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"data": store})
+}
+
+// ActivateStore godoc
+// @Summary Activate a store
+// @Description Marks a merchant-owned store as published
+// @Tags store
+// @Produce json
+// @Param id path int true "Store ID"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 403 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /merchant/stores/{id}/activate [post]
+func (h *StoreHandler) Activate(c *gin.Context) {
+	userID := c.GetInt64("user_id")
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	storeID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	if err := h.svc.Activate(c.Request.Context(), userID, storeID); err != nil {
+		switch {
+		case errors.Is(err, service.ErrStoreNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		case errors.Is(err, service.ErrStoreForbidden):
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to activate store"})
+		}
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// DeactivateStore godoc
+// @Summary Deactivate a store
+// @Description Marks a merchant-owned store as hidden
+// @Tags store
+// @Produce json
+// @Param id path int true "Store ID"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 403 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /merchant/stores/{id}/deactivate [post]
+func (h *StoreHandler) Deactivate(c *gin.Context) {
+	userID := c.GetInt64("user_id")
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	storeID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	if err := h.svc.Deactivate(c.Request.Context(), userID, storeID); err != nil {
+		switch {
+		case errors.Is(err, service.ErrStoreNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		case errors.Is(err, service.ErrStoreForbidden):
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to deactivate store"})
+		}
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }

--- a/apps/core/internal/domain/store/routes.go
+++ b/apps/core/internal/domain/store/routes.go
@@ -23,7 +23,10 @@ func RegisterRoutes(r *gin.RouterGroup, cfg *config.Config) {
 
 	merchantStores := r.Group("/merchant/stores", middleware.JWTAuth(cfg.JWT))
 	{
+		merchantStores.GET("", h.ListMine)
 		merchantStores.POST("", h.Create)
+		merchantStores.POST("/:id/activate", h.Activate)
+		merchantStores.POST("/:id/deactivate", h.Deactivate)
 		merchantStores.PATCH("/:id", h.Update)
 	}
 }

--- a/apps/core/internal/domain/store/service/service.go
+++ b/apps/core/internal/domain/store/service/service.go
@@ -17,6 +17,12 @@ type StoreService struct {
 	db *gorm.DB
 }
 
+const (
+	StoreStatusDraft     int16 = 0
+	StoreStatusPublished int16 = 1
+	StoreStatusHidden    int16 = 2
+)
+
 var ErrUserNotFound = errors.New("user not found")
 var ErrStoreNotFound = errors.New("store not found")
 var ErrStoreForbidden = errors.New("store forbidden")
@@ -83,6 +89,7 @@ func (s *StoreService) Create(ctx context.Context, userID int64, req dto.CreateS
 		Longitude:     req.Longitude,
 		CoverImageURL: req.CoverImageURL,
 		Images:        string(imagesRaw),
+		Status:        StoreStatusDraft,
 	}
 
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -113,6 +120,109 @@ func (s *StoreService) Create(ctx context.Context, userID int64, req dto.CreateS
 	}
 
 	return &store, nil
+}
+
+func (s *StoreService) ListPublished(ctx context.Context) ([]model.Store, error) {
+	var stores []model.Store
+	if err := s.db.WithContext(ctx).
+		Where("status = ?", StoreStatusPublished).
+		Order("id desc").
+		Find(&stores).Error; err != nil {
+		return nil, err
+	}
+	return stores, nil
+}
+
+func (s *StoreService) DetailPublished(ctx context.Context, storeID int64) (*model.Store, error) {
+	var store model.Store
+	if err := s.db.WithContext(ctx).
+		Preload("Hours").
+		Preload("Categories").
+		Where("id = ? AND status = ?", storeID, StoreStatusPublished).
+		First(&store).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrStoreNotFound
+		}
+		return nil, err
+	}
+	return &store, nil
+}
+
+func (s *StoreService) ReviewsPublished(ctx context.Context, storeID int64) ([]model.Review, error) {
+	if _, err := s.DetailPublished(ctx, storeID); err != nil {
+		return nil, err
+	}
+	var reviews []model.Review
+	if err := s.db.WithContext(ctx).
+		Where("store_id = ?", storeID).
+		Order("id desc").
+		Find(&reviews).Error; err != nil {
+		return nil, err
+	}
+	return reviews, nil
+}
+
+func (s *StoreService) HoursPublished(ctx context.Context, storeID int64) ([]model.StoreHour, error) {
+	if _, err := s.DetailPublished(ctx, storeID); err != nil {
+		return nil, err
+	}
+	var hours []model.StoreHour
+	if err := s.db.WithContext(ctx).
+		Where("store_id = ?", storeID).
+		Order("day_of_week asc").
+		Find(&hours).Error; err != nil {
+		return nil, err
+	}
+	return hours, nil
+}
+
+func (s *StoreService) ListMine(ctx context.Context, userID int64) ([]model.Store, error) {
+	var stores []model.Store
+	if err := s.db.WithContext(ctx).
+		Model(&model.Store{}).
+		Joins("JOIN merchants ON merchants.id = stores.merchant_id").
+		Where("merchants.user_id = ?", userID).
+		Order("stores.id desc").
+		Find(&stores).Error; err != nil {
+		return nil, err
+	}
+	return stores, nil
+}
+
+func (s *StoreService) Activate(ctx context.Context, userID, storeID int64) error {
+	return s.updateStatusOwned(ctx, userID, storeID, StoreStatusPublished)
+}
+
+func (s *StoreService) Deactivate(ctx context.Context, userID, storeID int64) error {
+	return s.updateStatusOwned(ctx, userID, storeID, StoreStatusHidden)
+}
+
+func (s *StoreService) updateStatusOwned(ctx context.Context, userID, storeID int64, toStatus int16) error {
+	var merchant model.Merchant
+	if err := s.db.WithContext(ctx).Where("user_id = ?", userID).First(&merchant).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrStoreForbidden
+		}
+		return err
+	}
+
+	var store model.Store
+	if err := s.db.WithContext(ctx).First(&store, storeID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrStoreNotFound
+		}
+		return err
+	}
+	if store.MerchantID != merchant.ID {
+		return ErrStoreForbidden
+	}
+	if store.Status == toStatus {
+		return nil
+	}
+	return s.db.WithContext(ctx).
+		Model(&model.Store{}).
+		Where("id = ?", storeID).
+		UpdateColumn("status", toStatus).Error
 }
 
 func (s *StoreService) Update(ctx context.Context, userID, storeID int64, req dto.UpdateStoreRequest) (*model.Store, error) {

--- a/apps/core/internal/domain/store/service/service_test.go
+++ b/apps/core/internal/domain/store/service/service_test.go
@@ -20,7 +20,7 @@ func setupStoreTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to open test db: %v", err)
 	}
 
-	if err := db.AutoMigrate(&model.User{}, &model.Merchant{}, &model.Store{}, &model.StoreHour{}); err != nil {
+	if err := db.AutoMigrate(&model.User{}, &model.Merchant{}, &model.Store{}, &model.StoreHour{}, &model.Category{}, &model.StoreCategory{}); err != nil {
 		t.Fatalf("failed to migrate test db: %v", err)
 	}
 
@@ -68,6 +68,9 @@ func TestStoreServiceCreate(t *testing.T) {
 	}
 	if store.MerchantID != merchant.ID {
 		t.Fatalf("unexpected merchant id: got %d, want %d", store.MerchantID, merchant.ID)
+	}
+	if store.Status != StoreStatusDraft {
+		t.Fatalf("unexpected store status: got %d, want %d", store.Status, StoreStatusDraft)
 	}
 	if store.Images != "[\"https://img.example/1.jpg\",\"https://img.example/2.jpg\"]" {
 		t.Fatalf("unexpected images json: %s", store.Images)
@@ -325,6 +328,211 @@ func TestStoreServiceUpdateStoreNotFound(t *testing.T) {
 	_, err := svc.Update(context.Background(), userID, 9999, dto.UpdateStoreRequest{Name: strPtr("Missing Store")})
 	if !errors.Is(err, ErrStoreNotFound) {
 		t.Fatalf("expected ErrStoreNotFound, got %v", err)
+	}
+}
+
+func TestStoreServiceActivateOwnStore(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	userID := int64(1001)
+	if err := db.Create(&model.User{ID: userID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &userID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Draft Store", Status: StoreStatusDraft}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	if err := svc.Activate(context.Background(), userID, store.ID); err != nil {
+		t.Fatalf("activate returned error: %v", err)
+	}
+
+	var refreshed model.Store
+	if err := db.First(&refreshed, store.ID).Error; err != nil {
+		t.Fatalf("failed to reload store: %v", err)
+	}
+	if refreshed.Status != StoreStatusPublished {
+		t.Fatalf("unexpected status after activation: got %d, want %d", refreshed.Status, StoreStatusPublished)
+	}
+}
+
+func TestStoreServiceActivateNonOwnerForbidden(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	ownerID := int64(2001)
+	otherID := int64(2002)
+	for _, id := range []int64{ownerID, otherID} {
+		if err := db.Create(&model.User{ID: id, Role: "user", Status: 0}).Error; err != nil {
+			t.Fatalf("failed to create user %d: %v", id, err)
+		}
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &ownerID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Draft Store", Status: StoreStatusDraft}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	err := svc.Activate(context.Background(), otherID, store.ID)
+	if !errors.Is(err, ErrStoreForbidden) {
+		t.Fatalf("expected ErrStoreForbidden, got %v", err)
+	}
+}
+
+func TestStoreServiceDeactivateOwnStore(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	userID := int64(3001)
+	if err := db.Create(&model.User{ID: userID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &userID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Published Store", Status: StoreStatusPublished}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	if err := svc.Deactivate(context.Background(), userID, store.ID); err != nil {
+		t.Fatalf("deactivate returned error: %v", err)
+	}
+
+	var refreshed model.Store
+	if err := db.First(&refreshed, store.ID).Error; err != nil {
+		t.Fatalf("failed to reload store: %v", err)
+	}
+	if refreshed.Status != StoreStatusHidden {
+		t.Fatalf("unexpected status after deactivation: got %d, want %d", refreshed.Status, StoreStatusHidden)
+	}
+}
+
+func TestStoreServiceListPublished(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	merchant := model.Merchant{Name: "Demo"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	draft := model.Store{MerchantID: merchant.ID, Name: "Draft", Status: StoreStatusDraft}
+	published := model.Store{MerchantID: merchant.ID, Name: "Published", Status: StoreStatusPublished}
+	if err := db.Create(&draft).Error; err != nil {
+		t.Fatalf("failed to create draft store: %v", err)
+	}
+	if err := db.Create(&published).Error; err != nil {
+		t.Fatalf("failed to create published store: %v", err)
+	}
+
+	stores, err := svc.ListPublished(context.Background())
+	if err != nil {
+		t.Fatalf("list published returned error: %v", err)
+	}
+	if len(stores) != 1 {
+		t.Fatalf("unexpected published stores count: got %d, want 1", len(stores))
+	}
+	if stores[0].ID != published.ID {
+		t.Fatalf("unexpected published store id: got %d, want %d", stores[0].ID, published.ID)
+	}
+}
+
+func TestStoreServiceListMine(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	userID := int64(4001)
+	otherID := int64(4002)
+	for _, id := range []int64{userID, otherID} {
+		if err := db.Create(&model.User{ID: id, Role: "user", Status: 0}).Error; err != nil {
+			t.Fatalf("failed to create user %d: %v", id, err)
+		}
+	}
+
+	myMerchant := model.Merchant{Name: "Mine", UserID: &userID}
+	otherMerchant := model.Merchant{Name: "Other", UserID: &otherID}
+	if err := db.Create(&myMerchant).Error; err != nil {
+		t.Fatalf("failed to create my merchant: %v", err)
+	}
+	if err := db.Create(&otherMerchant).Error; err != nil {
+		t.Fatalf("failed to create other merchant: %v", err)
+	}
+
+	myStore := model.Store{MerchantID: myMerchant.ID, Name: "My Store", Status: StoreStatusDraft}
+	otherStore := model.Store{MerchantID: otherMerchant.ID, Name: "Other Store", Status: StoreStatusPublished}
+	if err := db.Create(&myStore).Error; err != nil {
+		t.Fatalf("failed to create my store: %v", err)
+	}
+	if err := db.Create(&otherStore).Error; err != nil {
+		t.Fatalf("failed to create other store: %v", err)
+	}
+
+	stores, err := svc.ListMine(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("list mine returned error: %v", err)
+	}
+	if len(stores) != 1 {
+		t.Fatalf("unexpected mine stores count: got %d, want 1", len(stores))
+	}
+	if stores[0].ID != myStore.ID {
+		t.Fatalf("unexpected mine store id: got %d, want %d", stores[0].ID, myStore.ID)
+	}
+}
+
+func TestStoreServiceDetailPublishedPreloadsHoursAndCategories(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	merchant := model.Merchant{Name: "Detail Merchant"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+
+	store := model.Store{MerchantID: merchant.ID, Name: "Published Detail", Status: StoreStatusPublished}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	hour := model.StoreHour{StoreID: store.ID, DayOfWeek: 1, OpenTime: "09:00", CloseTime: "18:00"}
+	if err := db.Create(&hour).Error; err != nil {
+		t.Fatalf("failed to create store hour: %v", err)
+	}
+
+	category := model.Category{Name: "Cafe"}
+	if err := db.Create(&category).Error; err != nil {
+		t.Fatalf("failed to create category: %v", err)
+	}
+	storeCategory := model.StoreCategory{StoreID: store.ID, CategoryID: category.ID}
+	if err := db.Create(&storeCategory).Error; err != nil {
+		t.Fatalf("failed to create store category relation: %v", err)
+	}
+
+	detail, err := svc.DetailPublished(context.Background(), store.ID)
+	if err != nil {
+		t.Fatalf("detail published returned error: %v", err)
+	}
+
+	if len(detail.Hours) != 1 {
+		t.Fatalf("expected 1 hour preloaded, got %d", len(detail.Hours))
+	}
+	if detail.Hours[0].DayOfWeek != 1 {
+		t.Fatalf("unexpected preloaded hour day: %d", detail.Hours[0].DayOfWeek)
+	}
+
+	if len(detail.Categories) != 1 {
+		t.Fatalf("expected 1 category preloaded, got %d", len(detail.Categories))
+	}
+	if detail.Categories[0].Name != "Cafe" {
+		t.Fatalf("unexpected preloaded category: %q", detail.Categories[0].Name)
 	}
 }
 

--- a/apps/core/internal/router/openapi_v1_test.go
+++ b/apps/core/internal/router/openapi_v1_test.go
@@ -40,6 +40,21 @@ func setupAPITest(t *testing.T) (*gin.Engine, string) {
 	return r, tok
 }
 
+func issueAPITestToken(t *testing.T, user model.User, identifier string) string {
+	t.Helper()
+
+	db := database.DB
+	auth := model.UserAuth{UserID: user.ID, IdentityType: "email", Identifier: identifier}
+	if err := db.Create(&auth).Error; err != nil {
+		t.Fatalf("failed to create auth: %v", err)
+	}
+	tok, err := token.New(config.JWTConfig{Secret: "test-secret", ExpireHour: 24}).GenerateToken(&user, &auth)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+	return tok
+}
+
 func TestFeedHome(t *testing.T) {
 	r, _ := setupAPITest(t)
 	w := httptest.NewRecorder()
@@ -98,6 +113,167 @@ func TestMerchantReviews(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestStoreCreateActivateAndPublicVisibility(t *testing.T) {
+	r, tok := setupAPITest(t)
+
+	createBody := strings.NewReader(`{"name":"Draft Store","address":"Austin"}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/merchant/stores", createBody)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected create 201, got %d", w.Code)
+	}
+
+	var created struct {
+		Data model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+	if created.Data.Status != 0 {
+		t.Fatalf("expected created store status 0(draft), got %d", created.Data.Status)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/api/v1/stores", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected list 200, got %d", w.Code)
+	}
+	var listed struct {
+		Data []model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("failed to decode stores list response: %v", err)
+	}
+	if len(listed.Data) != 0 {
+		t.Fatalf("expected no public stores before activation, got %d", len(listed.Data))
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/merchant/stores/%d/activate", created.Data.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected activate 200, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/api/v1/stores", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected list 200 after activate, got %d", w.Code)
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("failed to decode stores list response after activate: %v", err)
+	}
+	if len(listed.Data) != 1 {
+		t.Fatalf("expected one public store after activation, got %d", len(listed.Data))
+	}
+	if listed.Data[0].ID != created.Data.ID {
+		t.Fatalf("unexpected public store id: got %d, want %d", listed.Data[0].ID, created.Data.ID)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/merchant/stores/%d/deactivate", created.Data.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected deactivate 200, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/stores/%d", created.Data.ID), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected detail 404 after deactivate, got %d", w.Code)
+	}
+}
+
+func TestStoreActivateForbiddenForNonOwner(t *testing.T) {
+	r, ownerToken := setupAPITest(t)
+
+	createBody := strings.NewReader(`{"name":"Owner Store","address":"Austin"}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/merchant/stores", createBody)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected create 201, got %d", w.Code)
+	}
+	var created struct {
+		Data model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+
+	db := database.DB
+	other := model.User{Role: "user", Status: 0}
+	if err := db.Create(&other).Error; err != nil {
+		t.Fatalf("failed to create other user: %v", err)
+	}
+	otherToken := issueAPITestToken(t, other, "other@example.com")
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/merchant/stores/%d/activate", created.Data.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+otherToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected forbidden activate for non-owner, got %d", w.Code)
+	}
+}
+
+func TestStoreDetailIncludesHoursAndCategories(t *testing.T) {
+	r, _ := setupAPITest(t)
+	db := database.DB
+
+	merchant := model.Merchant{Name: "Detail Merchant"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Published Store", Status: 1}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	hour := model.StoreHour{StoreID: store.ID, DayOfWeek: 1, OpenTime: "09:00", CloseTime: "18:00"}
+	if err := db.Create(&hour).Error; err != nil {
+		t.Fatalf("failed to create store hour: %v", err)
+	}
+	category := model.Category{Name: "Cafe"}
+	if err := db.Create(&category).Error; err != nil {
+		t.Fatalf("failed to create category: %v", err)
+	}
+	storeCategory := model.StoreCategory{StoreID: store.ID, CategoryID: category.ID}
+	if err := db.Create(&storeCategory).Error; err != nil {
+		t.Fatalf("failed to create store category relation: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/stores/%d", store.ID), nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp struct {
+		Data model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Data.Hours) != 1 {
+		t.Fatalf("expected 1 hour in detail, got %d", len(resp.Data.Hours))
+	}
+	if len(resp.Data.Categories) != 1 {
+		t.Fatalf("expected 1 category in detail, got %d", len(resp.Data.Categories))
 	}
 }
 

--- a/apps/core/internal/testutil/db.go
+++ b/apps/core/internal/testutil/db.go
@@ -26,6 +26,8 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 		&model.Merchant{},
 		&model.Store{},
 		&model.StoreHour{},
+		&model.Category{},
+		&model.StoreCategory{},
 		&model.Tag{},
 		&model.Post{},
 		&model.Review{},


### PR DESCRIPTION
Restore P0 store activation and publish visibility baseline: create as draft, public reads on published stores, owner-only activate/deactivate, and merchant-owned store listing.

Also complete #109 detail behavior by preloading store hours and categories for published store detail responses.

Tests: add service/router coverage for status transition, visibility guards, ownership checks, and detail payload associations. Update test DB migration to include category join tables. Regenerate Swagger artifacts.

Closes #147

Closes #109