### PR TITLE
feat(store): add filtering + cursor pagination for public store endpoints (#108 #110)

### DIFF
--- a/apps/core/docs/docs.go
+++ b/apps/core/docs/docs.go
@@ -2416,12 +2416,65 @@ const docTemplate = `{
                     "store"
                 ],
                 "summary": "List stores",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Category name or ID",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Latitude",
+                        "name": "lat",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Longitude",
+                        "name": "lng",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Minimum average rating",
+                        "name": "rating",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Search radius in KM (default 20)",
+                        "name": "radius_km",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Cursor for pagination (store id)",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "500": {
@@ -2549,6 +2602,18 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Cursor for pagination (review id)",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (max 100)",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/apps/core/docs/swagger.json
+++ b/apps/core/docs/swagger.json
@@ -2414,12 +2414,65 @@
                     "store"
                 ],
                 "summary": "List stores",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Category name or ID",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Latitude",
+                        "name": "lat",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Longitude",
+                        "name": "lng",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Minimum average rating",
+                        "name": "rating",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Search radius in KM (default 20)",
+                        "name": "radius_km",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Cursor for pagination (store id)",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "500": {
@@ -2547,6 +2600,18 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Cursor for pagination (review id)",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (max 100)",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/apps/core/docs/swagger.yaml
+++ b/apps/core/docs/swagger.yaml
@@ -2163,6 +2163,35 @@ paths:
   /stores:
     get:
       description: Returns a list of stores
+      parameters:
+      - description: Category name or ID
+        in: query
+        name: category
+        type: string
+      - description: Latitude
+        in: query
+        name: lat
+        type: number
+      - description: Longitude
+        in: query
+        name: lng
+        type: number
+      - description: Minimum average rating
+        in: query
+        name: rating
+        type: number
+      - description: Search radius in KM (default 20)
+        in: query
+        name: radius_km
+        type: number
+      - description: Cursor for pagination (store id)
+        in: query
+        name: cursor
+        type: integer
+      - description: Page size (max 100)
+        in: query
+        name: limit
+        type: integer
       produces:
       - application/json
       responses:
@@ -2170,6 +2199,12 @@ paths:
           description: OK
           schema:
             additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
             type: object
         "500":
           description: Internal Server Error
@@ -2252,6 +2287,14 @@ paths:
         in: path
         name: id
         required: true
+        type: integer
+      - description: Cursor for pagination (review id)
+        in: query
+        name: cursor
+        type: integer
+      - description: Page size (max 100)
+        in: query
+        name: limit
         type: integer
       produces:
       - application/json

--- a/apps/core/internal/domain/store/dto/store.go
+++ b/apps/core/internal/domain/store/dto/store.go
@@ -42,3 +42,20 @@ type StoreHourRequest struct {
 	CloseTime string `json:"close_time" binding:"max=10"`
 	IsClosed  bool   `json:"is_closed"`
 }
+
+// StoreListQuery controls public store list filters.
+type StoreListQuery struct {
+	Category *string  // category name or id
+	Lat      *float64 // latitude for proximity filter
+	Lng      *float64 // longitude for proximity filter
+	Rating   *float32 // min average rating
+	RadiusKM *float64 // optional radius in KM for location filter
+	Cursor   *int64   // id cursor for pagination (id < cursor)
+	Limit    *int     // max rows
+}
+
+// StoreReviewListQuery controls public store reviews pagination.
+type StoreReviewListQuery struct {
+	Cursor *int64 // id cursor for pagination (id < cursor)
+	Limit  *int   // max rows
+}

--- a/apps/core/internal/domain/store/handler/store.go
+++ b/apps/core/internal/domain/store/handler/store.go
@@ -27,16 +27,30 @@ func NewStoreHandler(svc *service.StoreService) *StoreHandler {
 // @Description Returns a list of stores
 // @Tags store
 // @Produce json
+// @Param category query string false "Category name or ID"
+// @Param lat query number false "Latitude"
+// @Param lng query number false "Longitude"
+// @Param rating query number false "Minimum average rating"
+// @Param radius_km query number false "Search radius in KM (default 20)"
+// @Param cursor query int false "Cursor for pagination (store id)"
+// @Param limit query int false "Page size (max 100)"
 // @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /stores [get]
 func (h *StoreHandler) List(c *gin.Context) {
-	stores, err := h.svc.ListPublished(c.Request.Context())
+	query, err := parseStoreListQuery(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	stores, cursor, err := h.svc.ListPublishedFiltered(c.Request.Context(), query)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list stores"})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"data": stores})
+	c.JSON(http.StatusOK, gin.H{"data": stores, "cursor": cursor})
 }
 
 // StoreDetail godoc
@@ -73,6 +87,8 @@ func (h *StoreHandler) Detail(c *gin.Context) {
 // @Tags store
 // @Produce json
 // @Param id path int true "Store ID"
+// @Param cursor query int false "Cursor for pagination (review id)"
+// @Param limit query int false "Page size (max 100)"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} map[string]string
 // @Failure 404 {object} map[string]string
@@ -83,7 +99,13 @@ func (h *StoreHandler) Reviews(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
 		return
 	}
-	reviews, err := h.svc.ReviewsPublished(c.Request.Context(), id)
+	query, err := parseStoreReviewListQuery(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	reviews, cursor, err := h.svc.ReviewsPublishedPaginated(c.Request.Context(), id, query)
 	if err != nil {
 		if errors.Is(err, service.ErrStoreNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
@@ -92,7 +114,7 @@ func (h *StoreHandler) Reviews(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load reviews"})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"data": reviews})
+	c.JSON(http.StatusOK, gin.H{"data": reviews, "cursor": cursor})
 }
 
 // StoreHours godoc
@@ -317,4 +339,134 @@ func (h *StoreHandler) Deactivate(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func parseStoreListQuery(c *gin.Context) (dto.StoreListQuery, error) {
+	var q dto.StoreListQuery
+
+	if category := c.Query("category"); category != "" {
+		q.Category = &category
+	}
+
+	lat, hasLat, err := parseFloat64Query(c, "lat")
+	if err != nil {
+		return q, err
+	}
+	lng, hasLng, err := parseFloat64Query(c, "lng")
+	if err != nil {
+		return q, err
+	}
+	if hasLat != hasLng {
+		return q, errors.New("lat and lng must be provided together")
+	}
+	if hasLat {
+		q.Lat = &lat
+		q.Lng = &lng
+	}
+
+	rating, hasRating, err := parseFloat32Query(c, "rating")
+	if err != nil {
+		return q, err
+	}
+	if hasRating {
+		q.Rating = &rating
+	}
+
+	radiusKM, hasRadiusKM, err := parseFloat64Query(c, "radius_km")
+	if err != nil {
+		return q, err
+	}
+	if hasRadiusKM {
+		if radiusKM <= 0 {
+			return q, errors.New("radius_km must be greater than 0")
+		}
+		q.RadiusKM = &radiusKM
+	}
+
+	cursor, hasCursor, err := parseInt64Query(c, "cursor")
+	if err != nil {
+		return q, err
+	}
+	if hasCursor {
+		q.Cursor = &cursor
+	}
+
+	limit, hasLimit, err := parseIntQuery(c, "limit")
+	if err != nil {
+		return q, err
+	}
+	if hasLimit {
+		q.Limit = &limit
+	}
+
+	return q, nil
+}
+
+func parseStoreReviewListQuery(c *gin.Context) (dto.StoreReviewListQuery, error) {
+	var q dto.StoreReviewListQuery
+
+	cursor, hasCursor, err := parseInt64Query(c, "cursor")
+	if err != nil {
+		return q, err
+	}
+	if hasCursor {
+		q.Cursor = &cursor
+	}
+
+	limit, hasLimit, err := parseIntQuery(c, "limit")
+	if err != nil {
+		return q, err
+	}
+	if hasLimit {
+		q.Limit = &limit
+	}
+	return q, nil
+}
+
+func parseIntQuery(c *gin.Context, key string) (int, bool, error) {
+	raw := c.Query(key)
+	if raw == "" {
+		return 0, false, nil
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false, errors.New("invalid " + key)
+	}
+	return parsed, true, nil
+}
+
+func parseInt64Query(c *gin.Context, key string) (int64, bool, error) {
+	raw := c.Query(key)
+	if raw == "" {
+		return 0, false, nil
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, false, errors.New("invalid " + key)
+	}
+	return parsed, true, nil
+}
+
+func parseFloat64Query(c *gin.Context, key string) (float64, bool, error) {
+	raw := c.Query(key)
+	if raw == "" {
+		return 0, false, nil
+	}
+	parsed, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, false, errors.New("invalid " + key)
+	}
+	return parsed, true, nil
+}
+
+func parseFloat32Query(c *gin.Context, key string) (float32, bool, error) {
+	raw := c.Query(key)
+	if raw == "" {
+		return 0, false, nil
+	}
+	parsed, err := strconv.ParseFloat(raw, 32)
+	if err != nil {
+		return 0, false, errors.New("invalid " + key)
+	}
+	return float32(parsed), true, nil
 }

--- a/apps/core/internal/domain/store/service/service.go
+++ b/apps/core/internal/domain/store/service/service.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/store/dto"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
@@ -21,6 +23,12 @@ const (
 	StoreStatusDraft     int16 = 0
 	StoreStatusPublished int16 = 1
 	StoreStatusHidden    int16 = 2
+
+	defaultPublicListLimit   = 20
+	defaultReviewsListLimit  = 20
+	maxPublicListLimit       = 100
+	maxStoreReviewsListLimit = 100
+	defaultRadiusKM          = 20.0
 )
 
 var ErrUserNotFound = errors.New("user not found")
@@ -133,6 +141,59 @@ func (s *StoreService) ListPublished(ctx context.Context) ([]model.Store, error)
 	return stores, nil
 }
 
+func (s *StoreService) ListPublishedFiltered(ctx context.Context, query dto.StoreListQuery) ([]model.Store, *int64, error) {
+	limit := sanitizeLimit(query.Limit, defaultPublicListLimit, maxPublicListLimit)
+
+	dbQuery := s.db.WithContext(ctx).
+		Model(&model.Store{}).
+		Where("stores.status = ?", StoreStatusPublished)
+
+	if query.Category != nil && strings.TrimSpace(*query.Category) != "" {
+		dbQuery = dbQuery.
+			Joins("JOIN store_categories sc ON sc.store_id = stores.id").
+			Joins("JOIN categories c ON c.id = sc.category_id")
+
+		category := strings.TrimSpace(*query.Category)
+		if categoryID, err := strconv.ParseInt(category, 10, 64); err == nil {
+			dbQuery = dbQuery.Where("c.id = ?", categoryID)
+		} else {
+			dbQuery = dbQuery.Where("LOWER(c.name) = LOWER(?)", category)
+		}
+	}
+
+	if query.Rating != nil {
+		dbQuery = dbQuery.Where("stores.avg_rating >= ?", *query.Rating)
+	}
+
+	if query.Lat != nil && query.Lng != nil {
+		radiusKM := defaultRadiusKM
+		if query.RadiusKM != nil && *query.RadiusKM > 0 {
+			radiusKM = *query.RadiusKM
+		}
+		latDelta := radiusKM / 111.0
+		lngDelta := radiusKM / 111.0
+		dbQuery = dbQuery.
+			Where("stores.latitude BETWEEN ? AND ?", *query.Lat-latDelta, *query.Lat+latDelta).
+			Where("stores.longitude BETWEEN ? AND ?", *query.Lng-lngDelta, *query.Lng+lngDelta)
+	}
+
+	if query.Cursor != nil {
+		dbQuery = dbQuery.Where("stores.id < ?", *query.Cursor)
+	}
+
+	var stores []model.Store
+	if err := dbQuery.
+		Distinct("stores.*").
+		Order("stores.id desc").
+		Limit(limit + 1).
+		Find(&stores).Error; err != nil {
+		return nil, nil, err
+	}
+
+	pageItems, cursor := sliceStorePage(stores, limit)
+	return pageItems, cursor, nil
+}
+
 func (s *StoreService) DetailPublished(ctx context.Context, storeID int64) (*model.Store, error) {
 	var store model.Store
 	if err := s.db.WithContext(ctx).
@@ -160,6 +221,34 @@ func (s *StoreService) ReviewsPublished(ctx context.Context, storeID int64) ([]m
 		return nil, err
 	}
 	return reviews, nil
+}
+
+func (s *StoreService) ReviewsPublishedPaginated(ctx context.Context, storeID int64, query dto.StoreReviewListQuery) ([]model.Review, *int64, error) {
+	if _, err := s.DetailPublished(ctx, storeID); err != nil {
+		return nil, nil, err
+	}
+
+	limit := sanitizeLimit(query.Limit, defaultReviewsListLimit, maxStoreReviewsListLimit)
+
+	dbQuery := s.db.WithContext(ctx).
+		Model(&model.Review{}).
+		Preload("User").
+		Preload("User.Profile").
+		Where("store_id = ?", storeID)
+
+	if query.Cursor != nil {
+		dbQuery = dbQuery.Where("reviews.id < ?", *query.Cursor)
+	}
+
+	var reviews []model.Review
+	if err := dbQuery.
+		Order("reviews.id desc").
+		Limit(limit + 1).
+		Find(&reviews).Error; err != nil {
+		return nil, nil, err
+	}
+	pageItems, cursor := sliceReviewPage(reviews, limit)
+	return pageItems, cursor, nil
 }
 
 func (s *StoreService) HoursPublished(ctx context.Context, storeID int64) ([]model.StoreHour, error) {
@@ -333,4 +422,38 @@ func (s *StoreService) Update(ctx context.Context, userID, storeID int64, req dt
 		return nil, err
 	}
 	return &updated, nil
+}
+
+func sanitizeLimit(raw *int, defaultLimit, maxLimit int) int {
+	if raw == nil || *raw <= 0 {
+		return defaultLimit
+	}
+	if *raw > maxLimit {
+		return maxLimit
+	}
+	return *raw
+}
+
+func sliceStorePage(items []model.Store, limit int) ([]model.Store, *int64) {
+	if len(items) <= limit {
+		return items, nil
+	}
+	items = items[:limit]
+	if len(items) == 0 {
+		return items, nil
+	}
+	lastID := items[len(items)-1].ID
+	return items, &lastID
+}
+
+func sliceReviewPage(items []model.Review, limit int) ([]model.Review, *int64) {
+	if len(items) <= limit {
+		return items, nil
+	}
+	items = items[:limit]
+	if len(items) == 0 {
+		return items, nil
+	}
+	lastID := items[len(items)-1].ID
+	return items, &lastID
 }

--- a/apps/core/internal/domain/store/service/service_test.go
+++ b/apps/core/internal/domain/store/service/service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/store/dto"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
@@ -20,7 +21,16 @@ func setupStoreTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to open test db: %v", err)
 	}
 
-	if err := db.AutoMigrate(&model.User{}, &model.Merchant{}, &model.Store{}, &model.StoreHour{}, &model.Category{}, &model.StoreCategory{}); err != nil {
+	if err := db.AutoMigrate(
+		&model.User{},
+		&model.UserProfile{},
+		&model.Merchant{},
+		&model.Store{},
+		&model.StoreHour{},
+		&model.Category{},
+		&model.StoreCategory{},
+		&model.Review{},
+	); err != nil {
 		t.Fatalf("failed to migrate test db: %v", err)
 	}
 
@@ -534,6 +544,192 @@ func TestStoreServiceDetailPublishedPreloadsHoursAndCategories(t *testing.T) {
 	if detail.Categories[0].Name != "Cafe" {
 		t.Fatalf("unexpected preloaded category: %q", detail.Categories[0].Name)
 	}
+}
+
+func TestStoreServiceListPublishedFilteredByCategoryRatingLocationAndCursor(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	merchant := model.Merchant{Name: "Filter Merchant"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+
+	cafe := model.Category{Name: "Cafe"}
+	bakery := model.Category{Name: "Bakery"}
+	if err := db.Create(&cafe).Error; err != nil {
+		t.Fatalf("failed to create cafe category: %v", err)
+	}
+	if err := db.Create(&bakery).Error; err != nil {
+		t.Fatalf("failed to create bakery category: %v", err)
+	}
+
+	createStore := func(name string, status int16, rating float32, lat, lng float64, categoryID int64) model.Store {
+		store := model.Store{
+			MerchantID: merchant.ID,
+			Name:       name,
+			Status:     status,
+			AvgRating:  rating,
+			Latitude:   lat,
+			Longitude:  lng,
+		}
+		if err := db.Create(&store).Error; err != nil {
+			t.Fatalf("failed to create store %s: %v", name, err)
+		}
+		if categoryID != 0 {
+			if err := db.Create(&model.StoreCategory{StoreID: store.ID, CategoryID: categoryID}).Error; err != nil {
+				t.Fatalf("failed to create store-category relation for %s: %v", name, err)
+			}
+		}
+		return store
+	}
+
+	matchOld := createStore("Match Old", StoreStatusPublished, 4.1, 37.7750, -122.4190, cafe.ID)
+	matchNew := createStore("Match New", StoreStatusPublished, 4.8, 37.7752, -122.4188, cafe.ID)
+	_ = createStore("Low Rating", StoreStatusPublished, 3.0, 37.7751, -122.4189, cafe.ID)
+	_ = createStore("Far Away", StoreStatusPublished, 4.9, 39.0000, -120.0000, cafe.ID)
+	_ = createStore("Other Category", StoreStatusPublished, 4.9, 37.7753, -122.4187, bakery.ID)
+	_ = createStore("Draft Hidden", StoreStatusDraft, 4.9, 37.7751, -122.4189, cafe.ID)
+
+	lat := 37.7750
+	lng := -122.4190
+	rating := float32(4.0)
+	limit := 1
+	radiusKm := 5.0
+	firstPage, cursor, err := svc.ListPublishedFiltered(context.Background(), dto.StoreListQuery{
+		Category: categoryNamePtr("Cafe"),
+		Lat:      &lat,
+		Lng:      &lng,
+		Rating:   &rating,
+		RadiusKM: &radiusKm,
+		Limit:    &limit,
+	})
+	if err != nil {
+		t.Fatalf("list filtered first page returned error: %v", err)
+	}
+	if len(firstPage) != 1 {
+		t.Fatalf("expected first page size 1, got %d", len(firstPage))
+	}
+	if firstPage[0].ID != matchNew.ID {
+		t.Fatalf("unexpected first-page store id: got %d, want %d", firstPage[0].ID, matchNew.ID)
+	}
+	if cursor == nil {
+		t.Fatalf("expected cursor for second page")
+	}
+
+	secondPage, nextCursor, err := svc.ListPublishedFiltered(context.Background(), dto.StoreListQuery{
+		Category: categoryNamePtr("Cafe"),
+		Lat:      &lat,
+		Lng:      &lng,
+		Rating:   &rating,
+		RadiusKM: &radiusKm,
+		Limit:    &limit,
+		Cursor:   cursor,
+	})
+	if err != nil {
+		t.Fatalf("list filtered second page returned error: %v", err)
+	}
+	if len(secondPage) != 1 {
+		t.Fatalf("expected second page size 1, got %d", len(secondPage))
+	}
+	if secondPage[0].ID != matchOld.ID {
+		t.Fatalf("unexpected second-page store id: got %d, want %d", secondPage[0].ID, matchOld.ID)
+	}
+	if nextCursor != nil {
+		t.Fatalf("expected no further cursor after second page, got %d", *nextCursor)
+	}
+}
+
+func TestStoreServiceReviewsPublishedPaginatedPreloadsUser(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	merchant := model.Merchant{Name: "Review Merchant"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Review Store", Status: StoreStatusPublished}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	makeUserWithProfile := func(nickname string) model.User {
+		user := model.User{Role: "user", Status: 0}
+		if err := db.Create(&user).Error; err != nil {
+			t.Fatalf("failed to create user %s: %v", nickname, err)
+		}
+		profile := model.UserProfile{UserID: user.ID, Nickname: nickname}
+		if err := db.Create(&profile).Error; err != nil {
+			t.Fatalf("failed to create profile %s: %v", nickname, err)
+		}
+		return user
+	}
+
+	u1 := makeUserWithProfile("u1")
+	u2 := makeUserWithProfile("u2")
+	u3 := makeUserWithProfile("u3")
+
+	addReview := func(userID int64, content string) model.Review {
+		storeID := store.ID
+		review := model.Review{
+			UserID:     userID,
+			MerchantID: merchant.ID,
+			VenueID:    merchant.ID,
+			StoreID:    &storeID,
+			Rating:     4.5,
+			Content:    content,
+			VisitDate:  time.Now().UTC(),
+		}
+		if err := db.Create(&review).Error; err != nil {
+			t.Fatalf("failed to create review %s: %v", content, err)
+		}
+		return review
+	}
+
+	oldest := addReview(u1.ID, "first")
+	_ = addReview(u2.ID, "second")
+	_ = addReview(u3.ID, "third")
+
+	limit := 2
+	firstPage, cursor, err := svc.ReviewsPublishedPaginated(context.Background(), store.ID, dto.StoreReviewListQuery{
+		Limit: &limit,
+	})
+	if err != nil {
+		t.Fatalf("reviews first page returned error: %v", err)
+	}
+	if len(firstPage) != 2 {
+		t.Fatalf("expected first page size 2, got %d", len(firstPage))
+	}
+	if cursor == nil {
+		t.Fatalf("expected cursor for second review page")
+	}
+	if firstPage[0].User == nil || firstPage[0].User.Profile == nil {
+		t.Fatalf("expected user/profile to be preloaded on first review page")
+	}
+
+	secondPage, nextCursor, err := svc.ReviewsPublishedPaginated(context.Background(), store.ID, dto.StoreReviewListQuery{
+		Limit:  &limit,
+		Cursor: cursor,
+	})
+	if err != nil {
+		t.Fatalf("reviews second page returned error: %v", err)
+	}
+	if len(secondPage) != 1 {
+		t.Fatalf("expected second page size 1, got %d", len(secondPage))
+	}
+	if secondPage[0].ID != oldest.ID {
+		t.Fatalf("unexpected second-page review id: got %d, want %d", secondPage[0].ID, oldest.ID)
+	}
+	if nextCursor != nil {
+		t.Fatalf("expected no further cursor after second page, got %d", *nextCursor)
+	}
+	if secondPage[0].User == nil || secondPage[0].User.Profile == nil {
+		t.Fatalf("expected user/profile to be preloaded on second review page")
+	}
+}
+
+func categoryNamePtr(v string) *string {
+	return &v
 }
 
 func strPtr(v string) *string {

--- a/apps/core/internal/router/openapi_v1_test.go
+++ b/apps/core/internal/router/openapi_v1_test.go
@@ -277,6 +277,199 @@ func TestStoreDetailIncludesHoursAndCategories(t *testing.T) {
 	}
 }
 
+func TestStoreListSupportsFilteringAndCursorPagination(t *testing.T) {
+	r, _ := setupAPITest(t)
+	db := database.DB
+
+	merchant := model.Merchant{Name: "Filter Merchant"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+
+	cafe := model.Category{Name: "Cafe"}
+	bakery := model.Category{Name: "Bakery"}
+	if err := db.Create(&cafe).Error; err != nil {
+		t.Fatalf("failed to create cafe category: %v", err)
+	}
+	if err := db.Create(&bakery).Error; err != nil {
+		t.Fatalf("failed to create bakery category: %v", err)
+	}
+
+	createStore := func(name string, status int16, rating float32, lat, lng float64, categoryID int64) model.Store {
+		store := model.Store{
+			MerchantID: merchant.ID,
+			Name:       name,
+			Status:     status,
+			AvgRating:  rating,
+			Latitude:   lat,
+			Longitude:  lng,
+		}
+		if err := db.Create(&store).Error; err != nil {
+			t.Fatalf("failed to create store %s: %v", name, err)
+		}
+		if err := db.Create(&model.StoreCategory{StoreID: store.ID, CategoryID: categoryID}).Error; err != nil {
+			t.Fatalf("failed to create store category relation for %s: %v", name, err)
+		}
+		return store
+	}
+
+	matchOld := createStore("Match Old", 1, 4.1, 37.7750, -122.4190, cafe.ID)
+	matchNew := createStore("Match New", 1, 4.8, 37.7752, -122.4188, cafe.ID)
+	_ = createStore("Low Rating", 1, 3.0, 37.7751, -122.4189, cafe.ID)
+	_ = createStore("Far Away", 1, 4.9, 39.0000, -120.0000, cafe.ID)
+	_ = createStore("Other Category", 1, 4.9, 37.7753, -122.4187, bakery.ID)
+	_ = createStore("Draft", 0, 4.9, 37.7751, -122.4189, cafe.ID)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/stores?category=Cafe&rating=4&lat=37.7750&lng=-122.4190&radius_km=5&limit=1", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected first page 200, got %d", w.Code)
+	}
+
+	var firstPage struct {
+		Data   []model.Store `json:"data"`
+		Cursor *int64        `json:"cursor"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &firstPage); err != nil {
+		t.Fatalf("failed to decode first-page response: %v", err)
+	}
+	if len(firstPage.Data) != 1 {
+		t.Fatalf("expected first page size 1, got %d", len(firstPage.Data))
+	}
+	if firstPage.Data[0].ID != matchNew.ID {
+		t.Fatalf("unexpected first-page store id: got %d, want %d", firstPage.Data[0].ID, matchNew.ID)
+	}
+	if firstPage.Cursor == nil {
+		t.Fatalf("expected first page cursor")
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/stores?category=Cafe&rating=4&lat=37.7750&lng=-122.4190&radius_km=5&limit=1&cursor=%d", *firstPage.Cursor), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected second page 200, got %d", w.Code)
+	}
+
+	var secondPage struct {
+		Data   []model.Store `json:"data"`
+		Cursor *int64        `json:"cursor"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &secondPage); err != nil {
+		t.Fatalf("failed to decode second-page response: %v", err)
+	}
+	if len(secondPage.Data) != 1 {
+		t.Fatalf("expected second page size 1, got %d", len(secondPage.Data))
+	}
+	if secondPage.Data[0].ID != matchOld.ID {
+		t.Fatalf("unexpected second-page store id: got %d, want %d", secondPage.Data[0].ID, matchOld.ID)
+	}
+	if secondPage.Cursor != nil {
+		t.Fatalf("expected second page cursor to be nil")
+	}
+}
+
+func TestStoreReviewsSupportsCursorPaginationAndUserPreload(t *testing.T) {
+	r, _ := setupAPITest(t)
+	db := database.DB
+
+	merchant := model.Merchant{Name: "Review Merchant"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Published Store", Status: 1}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	makeUser := func(nickname string) model.User {
+		user := model.User{Role: "user", Status: 0}
+		if err := db.Create(&user).Error; err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+		profile := model.UserProfile{UserID: user.ID, Nickname: nickname}
+		if err := db.Create(&profile).Error; err != nil {
+			t.Fatalf("failed to create profile: %v", err)
+		}
+		return user
+	}
+
+	u1 := makeUser("u1")
+	u2 := makeUser("u2")
+	u3 := makeUser("u3")
+
+	addReview := func(userID int64, content string) model.Review {
+		storeID := store.ID
+		review := model.Review{
+			UserID:     userID,
+			MerchantID: merchant.ID,
+			VenueID:    merchant.ID,
+			StoreID:    &storeID,
+			Rating:     4.5,
+			Content:    content,
+		}
+		if err := db.Create(&review).Error; err != nil {
+			t.Fatalf("failed to create review: %v", err)
+		}
+		return review
+	}
+
+	oldest := addReview(u1.ID, "first")
+	_ = addReview(u2.ID, "second")
+	_ = addReview(u3.ID, "third")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/stores/%d/reviews?limit=2", store.ID), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected first page 200, got %d", w.Code)
+	}
+
+	var firstPage struct {
+		Data   []model.Review `json:"data"`
+		Cursor *int64         `json:"cursor"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &firstPage); err != nil {
+		t.Fatalf("failed to decode first-page reviews: %v", err)
+	}
+	if len(firstPage.Data) != 2 {
+		t.Fatalf("expected first page size 2, got %d", len(firstPage.Data))
+	}
+	if firstPage.Cursor == nil {
+		t.Fatalf("expected review cursor on first page")
+	}
+	if firstPage.Data[0].User == nil || firstPage.Data[0].User.Profile == nil {
+		t.Fatalf("expected user/profile preloaded on reviews")
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/stores/%d/reviews?limit=2&cursor=%d", store.ID, *firstPage.Cursor), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected second page 200, got %d", w.Code)
+	}
+
+	var secondPage struct {
+		Data   []model.Review `json:"data"`
+		Cursor *int64         `json:"cursor"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &secondPage); err != nil {
+		t.Fatalf("failed to decode second-page reviews: %v", err)
+	}
+	if len(secondPage.Data) != 1 {
+		t.Fatalf("expected second page size 1, got %d", len(secondPage.Data))
+	}
+	if secondPage.Data[0].ID != oldest.ID {
+		t.Fatalf("unexpected second-page review id: got %d, want %d", secondPage.Data[0].ID, oldest.ID)
+	}
+	if secondPage.Data[0].User == nil || secondPage.Data[0].User.Profile == nil {
+		t.Fatalf("expected user/profile preloaded on second page")
+	}
+	if secondPage.Cursor != nil {
+		t.Fatalf("expected second page cursor to be nil")
+	}
+}
+
 func TestReviewsList(t *testing.T) {
 	r, tok := setupAPITest(t)
 


### PR DESCRIPTION
## Summary
- add query filters and cursor pagination to `GET /api/v1/stores` (category/rating/lat/lng/radius_km/cursor/limit)
- add cursor pagination + user preload for `GET /api/v1/stores/:id/reviews`
- add service/router tests and regenerate Swagger docs

## Verification
- `cd apps/core && GOCACHE=/tmp/go-build go test ./...`
- `cd apps/core && GOCACHE=/tmp/go-build make swagger`
- local server API verification passed:
  - `GET /api/v1/stores` page1/page2 with cursor = 200
  - `GET /api/v1/stores/:id/reviews` page1/page2 with cursor = 200

Closes #108
Closes #110
