### PR TITLE
feat(chain): harden review-merchant-store consistency and category binding (#157 #158 #159 #160)

### DIFF
--- a/apps/core/docs/docs.go
+++ b/apps/core/docs/docs.go
@@ -4718,6 +4718,12 @@ const docTemplate = `{
                     "type": "string",
                     "maxLength": 255
                 },
+                "category_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "city": {
                     "type": "string",
                     "maxLength": 100
@@ -4799,6 +4805,12 @@ const docTemplate = `{
                 "address": {
                     "type": "string",
                     "maxLength": 255
+                },
+                "category_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 },
                 "city": {
                     "type": "string",

--- a/apps/core/docs/swagger.json
+++ b/apps/core/docs/swagger.json
@@ -4716,6 +4716,12 @@
                     "type": "string",
                     "maxLength": 255
                 },
+                "category_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "city": {
                     "type": "string",
                     "maxLength": 100
@@ -4797,6 +4803,12 @@
                 "address": {
                     "type": "string",
                     "maxLength": 255
+                },
+                "category_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 },
                 "city": {
                     "type": "string",

--- a/apps/core/docs/swagger.yaml
+++ b/apps/core/docs/swagger.yaml
@@ -257,6 +257,10 @@ definitions:
       address:
         maxLength: 255
         type: string
+      category_ids:
+        items:
+          type: integer
+        type: array
       city:
         maxLength: 100
         type: string
@@ -315,6 +319,10 @@ definitions:
       address:
         maxLength: 255
         type: string
+      category_ids:
+        items:
+          type: integer
+        type: array
       city:
         maxLength: 100
         type: string

--- a/apps/core/internal/domain/merchant/handler/merchant.go
+++ b/apps/core/internal/domain/merchant/handler/merchant.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -62,6 +63,10 @@ func (h *MerchantHandler) Detail(c *gin.Context) {
 	}
 	merchant, err := h.svc.Detail(c.Request.Context(), id)
 	if err != nil {
+		if errors.Is(err, service.ErrMerchantNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
 		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 		return
 	}
@@ -86,6 +91,10 @@ func (h *MerchantHandler) Reviews(c *gin.Context) {
 	}
 	reviews, err := h.svc.Reviews(c.Request.Context(), id)
 	if err != nil {
+		if errors.Is(err, service.ErrMerchantNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
 		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 		return
 	}

--- a/apps/core/internal/domain/merchant/service/service.go
+++ b/apps/core/internal/domain/merchant/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/pkg/database"
@@ -12,6 +13,8 @@ type MerchantService struct {
 	db *gorm.DB
 }
 
+var ErrMerchantNotFound = errors.New("merchant not found")
+
 func NewMerchantService(db *gorm.DB) *MerchantService {
 	if db == nil {
 		db = database.DB
@@ -20,7 +23,7 @@ func NewMerchantService(db *gorm.DB) *MerchantService {
 }
 
 func (s *MerchantService) List(ctx context.Context, category string) ([]model.Merchant, error) {
-	q := s.db.WithContext(ctx).Model(&model.Merchant{})
+	q := s.publicScope(s.db.WithContext(ctx).Model(&model.Merchant{}))
 	if category != "" {
 		q = q.Where("category = ?", category)
 	}
@@ -33,16 +36,26 @@ func (s *MerchantService) List(ctx context.Context, category string) ([]model.Me
 
 func (s *MerchantService) Detail(ctx context.Context, id int64) (*model.Merchant, error) {
 	var merchant model.Merchant
-	if err := s.db.WithContext(ctx).First(&merchant, id).Error; err != nil {
+	if err := s.publicScope(s.db.WithContext(ctx)).First(&merchant, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrMerchantNotFound
+		}
 		return nil, err
 	}
 	return &merchant, nil
 }
 
 func (s *MerchantService) Reviews(ctx context.Context, merchantID int64) ([]model.Review, error) {
+	if _, err := s.Detail(ctx, merchantID); err != nil {
+		return nil, err
+	}
 	var reviews []model.Review
 	if err := s.db.WithContext(ctx).Where("merchant_id = ?", merchantID).Order("id desc").Find(&reviews).Error; err != nil {
 		return nil, err
 	}
 	return reviews, nil
+}
+
+func (s *MerchantService) publicScope(q *gorm.DB) *gorm.DB {
+	return q.Where("status = ? AND verification_status = ?", 0, "verified")
 }

--- a/apps/core/internal/domain/review/service/service.go
+++ b/apps/core/internal/domain/review/service/service.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/review/dto"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/pkg/database"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type ReviewService struct {
@@ -48,14 +50,6 @@ func (s *ReviewService) Create(ctx context.Context, userID int64, req dto.Review
 		return model.Review{}, err
 	}
 
-	var merchant model.Merchant
-	if err := s.db.WithContext(ctx).Select("id").First(&merchant, merchantID).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return model.Review{}, ErrMerchantNotFound
-		}
-		return model.Review{}, err
-	}
-
 	venueID := merchantID
 	if req.VenueID != "" {
 		venueID, err = req.VenueIDValue()
@@ -68,21 +62,14 @@ func (s *ReviewService) Create(ctx context.Context, userID int64, req dto.Review
 		return model.Review{}, err
 	}
 	if storeID != nil {
-		var store model.Store
-		if err := s.db.WithContext(ctx).Select("id", "merchant_id").First(&store, *storeID).Error; err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return model.Review{}, ErrStoreNotFound
-			}
-			return model.Review{}, err
-		}
-		if store.MerchantID != merchantID {
-			return model.Review{}, ErrStoreMerchantMismatch
-		}
+		// Validation is completed inside transaction to keep a single, consistent read/write unit.
 	}
+
 	visitDate, err := req.VisitDateValue()
 	if err != nil {
 		return model.Review{}, err
 	}
+
 	imagesJSON, _ := json.Marshal(req.Images)
 	review := model.Review{
 		UserID:     userID,
@@ -94,31 +81,133 @@ func (s *ReviewService) Create(ctx context.Context, userID int64, req dto.Review
 		Images:     string(imagesJSON),
 		VisitDate:  visitDate,
 	}
-	if err := s.db.WithContext(ctx).Create(&review).Error; err != nil {
+
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var merchant model.Merchant
+		if err := tx.Select("id").First(&merchant, merchantID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrMerchantNotFound
+			}
+			return err
+		}
+
+		if storeID != nil {
+			var store model.Store
+			if err := tx.Select("id", "merchant_id").First(&store, *storeID).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return ErrStoreNotFound
+				}
+				return err
+			}
+			if store.MerchantID != merchantID {
+				return ErrStoreMerchantMismatch
+			}
+		}
+
+		if err := tx.Create(&review).Error; err != nil {
+			return err
+		}
+		if err := syncMerchantReviewAggregates(tx, merchantID); err != nil {
+			return err
+		}
+		if storeID != nil {
+			if err := syncStoreReviewAggregates(tx, *storeID); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
 		return model.Review{}, err
 	}
+
 	return review, nil
 }
 
 func (s *ReviewService) Like(ctx context.Context, userID, reviewID int64) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var review model.Review
-		if err := tx.First(&review, reviewID).Error; err != nil {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&review, reviewID).Error; err != nil {
 			return err
 		}
+
+		var existing model.Like
+		if err := tx.Where("user_id = ? AND target_type = ? AND target_id = ?", userID, "review", reviewID).
+			First(&existing).Error; err == nil {
+			return nil
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
 		like := model.Like{UserID: userID, TargetType: "review", TargetID: reviewID}
-		if err := tx.FirstOrCreate(&like, like).Error; err != nil {
+		if err := tx.Create(&like).Error; err != nil {
+			// Concurrent duplicate like should remain idempotent.
+			if errors.Is(err, gorm.ErrDuplicatedKey) || isUniqueViolation(err) {
+				return nil
+			}
 			return err
 		}
+
 		return tx.Model(&review).UpdateColumn("like_count", gorm.Expr("like_count + 1")).Error
 	})
 }
 
 func (s *ReviewService) Comment(ctx context.Context, userID, reviewID int64, text string) error {
-	var review model.Review
-	if err := s.db.WithContext(ctx).First(&review, reviewID).Error; err != nil {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var review model.Review
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&review, reviewID).Error; err != nil {
+			return err
+		}
+		comment := model.ReviewComment{ReviewID: reviewID, UserID: userID, Content: text}
+		if err := tx.Create(&comment).Error; err != nil {
+			return err
+		}
+		return tx.Model(&review).UpdateColumn("comment_count", gorm.Expr("comment_count + 1")).Error
+	})
+}
+
+func syncMerchantReviewAggregates(tx *gorm.DB, merchantID int64) error {
+	type aggregate struct {
+		Count int64
+		Avg   float64
+	}
+	var agg aggregate
+	if err := tx.Model(&model.Review{}).
+		Select("COUNT(*) AS count, COALESCE(AVG(rating), 0) AS avg").
+		Where("merchant_id = ?", merchantID).
+		Scan(&agg).Error; err != nil {
 		return err
 	}
-	comment := model.ReviewComment{ReviewID: reviewID, UserID: userID, Content: text}
-	return s.db.WithContext(ctx).Create(&comment).Error
+	updates := map[string]interface{}{
+		"review_count":  int(agg.Count),
+		"total_reviews": int(agg.Count),
+		"avg_rating":    float32(agg.Avg),
+	}
+	return tx.Model(&model.Merchant{}).Where("id = ?", merchantID).Updates(updates).Error
+}
+
+func syncStoreReviewAggregates(tx *gorm.DB, storeID int64) error {
+	type aggregate struct {
+		Count int64
+		Avg   float64
+	}
+	var agg aggregate
+	if err := tx.Model(&model.Review{}).
+		Select("COUNT(*) AS count, COALESCE(AVG(rating), 0) AS avg").
+		Where("store_id = ?", storeID).
+		Scan(&agg).Error; err != nil {
+		return err
+	}
+	updates := map[string]interface{}{
+		"review_count": int(agg.Count),
+		"avg_rating":   float32(agg.Avg),
+	}
+	return tx.Model(&model.Store{}).Where("id = ?", storeID).Updates(updates).Error
+}
+
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "duplicate key") || strings.Contains(msg, "UNIQUE constraint failed")
 }

--- a/apps/core/internal/domain/review/service/service_test.go
+++ b/apps/core/internal/domain/review/service/service_test.go
@@ -124,3 +124,136 @@ func TestReviewDetailPreloadsMerchantAndStore(t *testing.T) {
 		t.Fatalf("expected store preloaded")
 	}
 }
+
+func TestCreateReviewSyncsStoreAndMerchantAggregates(t *testing.T) {
+	svc, db, userID := setupReviewServiceTest(t)
+
+	merchant := model.Merchant{Name: "Cafe"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Downtown"}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	create := func(rating float64, text string) {
+		_, err := svc.Create(context.Background(), userID, dto.Review{
+			MerchantID: fmt.Sprintf("%d", merchant.ID),
+			StoreID:    fmt.Sprintf("%d", store.ID),
+			Rating:     rating,
+			Text:       text,
+		})
+		if err != nil {
+			t.Fatalf("create review failed: %v", err)
+		}
+	}
+
+	create(4.0, "good")
+	create(2.0, "ok")
+
+	var refreshedStore model.Store
+	if err := db.First(&refreshedStore, store.ID).Error; err != nil {
+		t.Fatalf("failed to reload store: %v", err)
+	}
+	if refreshedStore.ReviewCount != 2 {
+		t.Fatalf("unexpected store review_count: got %d want 2", refreshedStore.ReviewCount)
+	}
+	if refreshedStore.AvgRating != float32(3.0) {
+		t.Fatalf("unexpected store avg_rating: got %.2f want 3.00", refreshedStore.AvgRating)
+	}
+
+	var refreshedMerchant model.Merchant
+	if err := db.First(&refreshedMerchant, merchant.ID).Error; err != nil {
+		t.Fatalf("failed to reload merchant: %v", err)
+	}
+	if refreshedMerchant.ReviewCount != 2 {
+		t.Fatalf("unexpected merchant review_count: got %d want 2", refreshedMerchant.ReviewCount)
+	}
+	if refreshedMerchant.TotalReviews != 2 {
+		t.Fatalf("unexpected merchant total_reviews: got %d want 2", refreshedMerchant.TotalReviews)
+	}
+	if refreshedMerchant.AvgRating != float32(3.0) {
+		t.Fatalf("unexpected merchant avg_rating: got %.2f want 3.00", refreshedMerchant.AvgRating)
+	}
+}
+
+func TestLikeIsIdempotentPerUser(t *testing.T) {
+	svc, db, userID := setupReviewServiceTest(t)
+
+	merchant := model.Merchant{Name: "Cafe"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	review := model.Review{
+		UserID:     userID,
+		MerchantID: merchant.ID,
+		VenueID:    merchant.ID,
+		Rating:     4.0,
+		Content:    "nice",
+		VisitDate:  time.Now().UTC(),
+	}
+	if err := db.Create(&review).Error; err != nil {
+		t.Fatalf("failed to create review: %v", err)
+	}
+
+	if err := svc.Like(context.Background(), userID, review.ID); err != nil {
+		t.Fatalf("first like failed: %v", err)
+	}
+	if err := svc.Like(context.Background(), userID, review.ID); err != nil {
+		t.Fatalf("second like failed: %v", err)
+	}
+
+	var likes int64
+	if err := db.Model(&model.Like{}).
+		Where("user_id = ? AND target_type = ? AND target_id = ?", userID, "review", review.ID).
+		Count(&likes).Error; err != nil {
+		t.Fatalf("failed to count likes: %v", err)
+	}
+	if likes != 1 {
+		t.Fatalf("unexpected like rows: got %d want 1", likes)
+	}
+
+	var refreshed model.Review
+	if err := db.First(&refreshed, review.ID).Error; err != nil {
+		t.Fatalf("failed to reload review: %v", err)
+	}
+	if refreshed.LikeCount != 1 {
+		t.Fatalf("unexpected like_count: got %d want 1", refreshed.LikeCount)
+	}
+}
+
+func TestCommentIncrementsCommentCount(t *testing.T) {
+	svc, db, userID := setupReviewServiceTest(t)
+
+	merchant := model.Merchant{Name: "Cafe"}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	review := model.Review{
+		UserID:     userID,
+		MerchantID: merchant.ID,
+		VenueID:    merchant.ID,
+		Rating:     4.0,
+		Content:    "nice",
+		VisitDate:  time.Now().UTC(),
+	}
+	if err := db.Create(&review).Error; err != nil {
+		t.Fatalf("failed to create review: %v", err)
+	}
+
+	if err := svc.Comment(context.Background(), userID, review.ID, "first"); err != nil {
+		t.Fatalf("first comment failed: %v", err)
+	}
+	if err := svc.Comment(context.Background(), userID, review.ID, "second"); err != nil {
+		t.Fatalf("second comment failed: %v", err)
+	}
+
+	var refreshed model.Review
+	if err := db.First(&refreshed, review.ID).Error; err != nil {
+		t.Fatalf("failed to reload review: %v", err)
+	}
+	if refreshed.CommentCount != 2 {
+		t.Fatalf("unexpected comment_count: got %d want 2", refreshed.CommentCount)
+	}
+}

--- a/apps/core/internal/domain/store/dto/store.go
+++ b/apps/core/internal/domain/store/dto/store.go
@@ -16,6 +16,7 @@ type CreateStoreRequest struct {
 	CoverImageURL string             `json:"cover_image_url" binding:"max=255"`
 	Images        []string           `json:"images"`
 	Hours         []StoreHourRequest `json:"hours"`
+	CategoryIDs   []int64            `json:"category_ids"`
 }
 
 // UpdateStoreRequest is the request payload for partially updating a store.
@@ -34,6 +35,7 @@ type UpdateStoreRequest struct {
 	CoverImageURL *string             `json:"cover_image_url" binding:"omitempty,max=255"`
 	Images        *[]string           `json:"images"`
 	Hours         *[]StoreHourRequest `json:"hours"`
+	CategoryIDs   *[]int64            `json:"category_ids"`
 }
 
 type StoreHourRequest struct {

--- a/apps/core/internal/domain/store/handler/store.go
+++ b/apps/core/internal/domain/store/handler/store.go
@@ -203,6 +203,10 @@ func (h *StoreHandler) Create(c *gin.Context) {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 			return
 		}
+		if errors.Is(err, service.ErrCategoryNotFound) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid category ids"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create store"})
 		return
 	}
@@ -254,6 +258,8 @@ func (h *StoreHandler) Update(c *gin.Context) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 		case errors.Is(err, service.ErrStoreForbidden):
 			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		case errors.Is(err, service.ErrCategoryNotFound):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid category ids"})
 		default:
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update store"})
 		}

--- a/apps/core/internal/domain/store/service/service.go
+++ b/apps/core/internal/domain/store/service/service.go
@@ -34,6 +34,7 @@ const (
 var ErrUserNotFound = errors.New("user not found")
 var ErrStoreNotFound = errors.New("store not found")
 var ErrStoreForbidden = errors.New("store forbidden")
+var ErrCategoryNotFound = errors.New("category not found")
 
 func NewStoreService(db *gorm.DB) *StoreService {
 	if db == nil {
@@ -100,6 +101,11 @@ func (s *StoreService) Create(ctx context.Context, userID int64, req dto.CreateS
 		Status:        StoreStatusDraft,
 	}
 
+	categoryIDs, err := sanitizeCategoryIDs(req.CategoryIDs)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(&store).Error; err != nil {
 			return err
@@ -116,6 +122,18 @@ func (s *StoreService) Create(ctx context.Context, userID int64, req dto.CreateS
 				})
 			}
 			if err := tx.Create(&hours).Error; err != nil {
+				return err
+			}
+		}
+		if len(categoryIDs) > 0 {
+			if err := ensureCategoriesExist(tx, categoryIDs); err != nil {
+				return err
+			}
+			links := make([]model.StoreCategory, 0, len(categoryIDs))
+			for _, categoryID := range categoryIDs {
+				links = append(links, model.StoreCategory{StoreID: store.ID, CategoryID: categoryID})
+			}
+			if err := tx.Create(&links).Error; err != nil {
 				return err
 			}
 		}
@@ -380,6 +398,20 @@ func (s *StoreService) Update(ctx context.Context, userID, storeID int64, req dt
 	}
 
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var categoryIDs []int64
+		if req.CategoryIDs != nil {
+			normalized, err := sanitizeCategoryIDs(*req.CategoryIDs)
+			if err != nil {
+				return err
+			}
+			categoryIDs = normalized
+			if len(categoryIDs) > 0 {
+				if err := ensureCategoriesExist(tx, categoryIDs); err != nil {
+					return err
+				}
+			}
+		}
+
 		if len(updates) > 0 {
 			if err := tx.Model(&model.Store{}).
 				Where("id = ?", storeID).
@@ -409,13 +441,31 @@ func (s *StoreService) Update(ctx context.Context, userID, storeID int64, req dt
 			}
 		}
 
+		if req.CategoryIDs != nil {
+			if err := tx.Where("store_id = ?", storeID).Delete(&model.StoreCategory{}).Error; err != nil {
+				return err
+			}
+			if len(categoryIDs) > 0 {
+				links := make([]model.StoreCategory, 0, len(categoryIDs))
+				for _, categoryID := range categoryIDs {
+					links = append(links, model.StoreCategory{
+						StoreID:    storeID,
+						CategoryID: categoryID,
+					})
+				}
+				if err := tx.Create(&links).Error; err != nil {
+					return err
+				}
+			}
+		}
+
 		return nil
 	}); err != nil {
 		return nil, err
 	}
 
 	var updated model.Store
-	if err := s.db.WithContext(ctx).Preload("Hours").First(&updated, storeID).Error; err != nil {
+	if err := s.db.WithContext(ctx).Preload("Hours").Preload("Categories").First(&updated, storeID).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrStoreNotFound
 		}
@@ -456,4 +506,37 @@ func sliceReviewPage(items []model.Review, limit int) ([]model.Review, *int64) {
 	}
 	lastID := items[len(items)-1].ID
 	return items, &lastID
+}
+
+func sanitizeCategoryIDs(raw []int64) ([]int64, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	seen := make(map[int64]struct{}, len(raw))
+	normalized := make([]int64, 0, len(raw))
+	for _, id := range raw {
+		if id <= 0 {
+			return nil, ErrCategoryNotFound
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		normalized = append(normalized, id)
+	}
+	return normalized, nil
+}
+
+func ensureCategoriesExist(tx *gorm.DB, categoryIDs []int64) error {
+	if len(categoryIDs) == 0 {
+		return nil
+	}
+	var count int64
+	if err := tx.Model(&model.Category{}).Where("id IN ?", categoryIDs).Count(&count).Error; err != nil {
+		return err
+	}
+	if count != int64(len(categoryIDs)) {
+		return ErrCategoryNotFound
+	}
+	return nil
 }

--- a/apps/core/internal/domain/store/service/service_test.go
+++ b/apps/core/internal/domain/store/service/service_test.go
@@ -166,6 +166,65 @@ func TestStoreServiceCreateDefaultName(t *testing.T) {
 	}
 }
 
+func TestStoreServiceCreateBindsCategories(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	userID := int64(206)
+	if err := db.Create(&model.User{ID: userID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Category Merchant", UserID: &userID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	category := model.Category{Name: "Cafe"}
+	if err := db.Create(&category).Error; err != nil {
+		t.Fatalf("failed to create category: %v", err)
+	}
+
+	store, err := svc.Create(context.Background(), userID, dto.CreateStoreRequest{
+		Name:        "Category Store",
+		CategoryIDs: []int64{category.ID},
+	})
+	if err != nil {
+		t.Fatalf("create returned error: %v", err)
+	}
+
+	var links []model.StoreCategory
+	if err := db.Where("store_id = ?", store.ID).Find(&links).Error; err != nil {
+		t.Fatalf("failed to query store categories: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("expected 1 store category relation, got %d", len(links))
+	}
+	if links[0].CategoryID != category.ID {
+		t.Fatalf("unexpected category id: got %d want %d", links[0].CategoryID, category.ID)
+	}
+}
+
+func TestStoreServiceCreateWithInvalidCategoryReturnsNotFound(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	userID := int64(207)
+	if err := db.Create(&model.User{ID: userID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Category Merchant", UserID: &userID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+
+	_, err := svc.Create(context.Background(), userID, dto.CreateStoreRequest{
+		Name:        "Broken Category Store",
+		CategoryIDs: []int64{99999},
+	})
+	if !errors.Is(err, ErrCategoryNotFound) {
+		t.Fatalf("expected ErrCategoryNotFound, got %v", err)
+	}
+}
+
 func TestStoreServiceCreateUserNotFound(t *testing.T) {
 	db := setupStoreTestDB(t)
 	svc := NewStoreService(db)
@@ -296,6 +355,55 @@ func TestStoreServiceUpdateOwnStoreReplacesHours(t *testing.T) {
 	}
 	if hours[0].DayOfWeek != 5 || hours[0].OpenTime != "10:00" || hours[0].CloseTime != "20:00" || hours[0].IsClosed {
 		t.Fatalf("unexpected replaced hour row: %+v", hours[0])
+	}
+}
+
+func TestStoreServiceUpdateOwnStoreReplacesCategories(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	ownerID := int64(406)
+	if err := db.Create(&model.User{ID: ownerID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create owner user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &ownerID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+
+	store := model.Store{MerchantID: merchant.ID, Name: "Category Store"}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	c1 := model.Category{Name: "Cafe"}
+	c2 := model.Category{Name: "Bakery"}
+	if err := db.Create(&c1).Error; err != nil {
+		t.Fatalf("failed to create category c1: %v", err)
+	}
+	if err := db.Create(&c2).Error; err != nil {
+		t.Fatalf("failed to create category c2: %v", err)
+	}
+	if err := db.Create(&model.StoreCategory{StoreID: store.ID, CategoryID: c1.ID}).Error; err != nil {
+		t.Fatalf("failed to seed store category c1: %v", err)
+	}
+
+	_, err := svc.Update(context.Background(), ownerID, store.ID, dto.UpdateStoreRequest{
+		CategoryIDs: int64SlicePtr([]int64{c2.ID}),
+	})
+	if err != nil {
+		t.Fatalf("update returned error: %v", err)
+	}
+
+	var links []model.StoreCategory
+	if err := db.Where("store_id = ?", store.ID).Order("category_id asc").Find(&links).Error; err != nil {
+		t.Fatalf("failed to query store categories: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("expected 1 store category relation after replace, got %d", len(links))
+	}
+	if links[0].CategoryID != c2.ID {
+		t.Fatalf("unexpected replaced category id: got %d want %d", links[0].CategoryID, c2.ID)
 	}
 }
 
@@ -733,5 +841,9 @@ func categoryNamePtr(v string) *string {
 }
 
 func strPtr(v string) *string {
+	return &v
+}
+
+func int64SlicePtr(v []int64) *[]int64 {
 	return &v
 }

--- a/apps/core/internal/router/openapi_v1_test.go
+++ b/apps/core/internal/router/openapi_v1_test.go
@@ -70,7 +70,7 @@ func TestMerchantsList(t *testing.T) {
 	r, _ := setupAPITest(t)
 
 	db := database.DB
-	_ = db.Create(&model.Merchant{Name: "Cafe", Category: "food"}).Error
+	_ = db.Create(&model.Merchant{Name: "Cafe", Category: "food", VerificationStatus: "verified", Status: 0}).Error
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/api/v1/merchants", nil)
@@ -85,7 +85,7 @@ func TestMerchantDetail(t *testing.T) {
 	r, _ := setupAPITest(t)
 
 	db := database.DB
-	m := model.Merchant{Name: "Shop"}
+	m := model.Merchant{Name: "Shop", VerificationStatus: "verified", Status: 0}
 	_ = db.Create(&m).Error
 
 	w := httptest.NewRecorder()
@@ -103,7 +103,7 @@ func TestMerchantReviews(t *testing.T) {
 	db := database.DB
 	user := model.User{Role: "user", Status: 0}
 	_ = db.Create(&user).Error
-	m := model.Merchant{Name: "Shop"}
+	m := model.Merchant{Name: "Shop", VerificationStatus: "verified", Status: 0}
 	_ = db.Create(&m).Error
 	_ = db.Create(&model.Review{UserID: user.ID, MerchantID: m.ID, Rating: 4, Content: "nice"}).Error
 
@@ -113,6 +113,95 @@ func TestMerchantReviews(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestMerchantsListOnlyShowsPublicMerchants(t *testing.T) {
+	r, _ := setupAPITest(t)
+
+	db := database.DB
+	if err := db.Create(&model.Merchant{Name: "Public", VerificationStatus: "verified", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create public merchant: %v", err)
+	}
+	if err := db.Create(&model.Merchant{Name: "Unverified", VerificationStatus: "unverified", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create unverified merchant: %v", err)
+	}
+	if err := db.Create(&model.Merchant{Name: "Inactive", VerificationStatus: "verified", Status: 1}).Error; err != nil {
+		t.Fatalf("failed to create inactive merchant: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/merchants", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp struct {
+		Data []map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode merchant list response: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 public merchant, got %d", len(resp.Data))
+	}
+	name, _ := resp.Data[0]["name"].(string)
+	if name != "Public" {
+		t.Fatalf("unexpected merchant returned: %s", name)
+	}
+}
+
+func TestMerchantDetailReturnsNotFoundWhenNotPublic(t *testing.T) {
+	r, _ := setupAPITest(t)
+
+	db := database.DB
+	publicMerchant := model.Merchant{Name: "Public", VerificationStatus: "verified", Status: 0}
+	if err := db.Create(&publicMerchant).Error; err != nil {
+		t.Fatalf("failed to create public merchant: %v", err)
+	}
+	hiddenMerchant := model.Merchant{Name: "Hidden", VerificationStatus: "unverified", Status: 0}
+	if err := db.Create(&hiddenMerchant).Error; err != nil {
+		t.Fatalf("failed to create hidden merchant: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/merchants/%d", publicMerchant.ID), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected public merchant detail 200, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/merchants/%d", hiddenMerchant.ID), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected hidden merchant detail 404, got %d", w.Code)
+	}
+}
+
+func TestMerchantReviewsReturnsNotFoundWhenMerchantMissingOrNotPublic(t *testing.T) {
+	r, _ := setupAPITest(t)
+
+	db := database.DB
+	hidden := model.Merchant{Name: "Hidden", VerificationStatus: "unverified", Status: 0}
+	if err := db.Create(&hidden).Error; err != nil {
+		t.Fatalf("failed to create hidden merchant: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/merchants/99999/reviews", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected missing merchant reviews 404, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/merchants/%d/reviews", hidden.ID), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected hidden merchant reviews 404, got %d", w.Code)
 	}
 }
 
@@ -192,6 +281,109 @@ func TestStoreCreateActivateAndPublicVisibility(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected detail 404 after deactivate, got %d", w.Code)
+	}
+}
+
+func TestStoreCreateWithCategoriesReflectedInCategoryFilter(t *testing.T) {
+	r, tok := setupAPITest(t)
+	db := database.DB
+
+	category := model.Category{Name: "Cafe"}
+	if err := db.Create(&category).Error; err != nil {
+		t.Fatalf("failed to create category: %v", err)
+	}
+
+	createBody := strings.NewReader(fmt.Sprintf(`{"name":"Categorized Store","address":"Austin","category_ids":[%d]}`, category.ID))
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/merchant/stores", createBody)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected create 201, got %d", w.Code)
+	}
+
+	var created struct {
+		Data model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/merchant/stores/%d/activate", created.Data.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected activate 200, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/stores?category=%d", category.ID), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected category list 200, got %d", w.Code)
+	}
+
+	var listed struct {
+		Data []model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("failed to decode category list response: %v", err)
+	}
+	found := false
+	for _, s := range listed.Data {
+		if s.ID == created.Data.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected created categorized store to appear in category filter result")
+	}
+}
+
+func TestStoreCreateReturnsBadRequestWhenCategoryInvalid(t *testing.T) {
+	r, tok := setupAPITest(t)
+
+	createBody := strings.NewReader(`{"name":"Broken Category Store","category_ids":[99999]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/merchant/stores", createBody)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected create 400 for invalid categories, got %d", w.Code)
+	}
+}
+
+func TestStoreUpdateReturnsBadRequestWhenCategoryInvalid(t *testing.T) {
+	r, tok := setupAPITest(t)
+	db := database.DB
+
+	var ownerAuth model.UserAuth
+	if err := db.Where("identifier = ?", "user@example.com").First(&ownerAuth).Error; err != nil {
+		t.Fatalf("failed to load owner auth: %v", err)
+	}
+	ownerMerchant := model.Merchant{Name: "Owner Merchant", UserID: &ownerAuth.UserID}
+	if err := db.Create(&ownerMerchant).Error; err != nil {
+		t.Fatalf("failed to create owner merchant: %v", err)
+	}
+	store := model.Store{MerchantID: ownerMerchant.ID, Name: "Category Update Store"}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	body := strings.NewReader(`{"category_ids":[99999]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/merchant/stores/%d", store.ID), body)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected update 400 for invalid categories, got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary
- sync merchant/store aggregates after review writes (`avg_rating`, `review_count`, `total_reviews`)
- make review like/comment counters consistent and idempotent
- enforce merchant public visibility and merchant reviews not-found semantics
- support `category_ids` binding on store create/update with category validation
- update tests and regenerate Swagger docs

## Verification
- `cd apps/core && GOCACHE=/tmp/go-build go test ./...`
- `cd apps/core && GOCACHE=/tmp/go-build make swagger`

Closes #157
Closes #158
Closes #159
Closes #160
