### PR TITLE
feat: deliver soft-delete deletion flows and user account deletion executor (#173-#178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,21 @@ docker run -p 8080:8080 revieu-core
 
 ## 📚 Documentation
 
+- [Database ERD (SVG)](docs/database-erd.svg) - Full database schema with PK/FK markers and FK links
 - [Scripts README](scripts/README.md) - Secrets management and hooks
 - [Core Service](apps/core/) - API documentation
 - [Infrastructure Repo](https://github.com/RevieU-Corp/revieu-infra) - K8s configs
+
+### Regenerate Database ERD
+
+```bash
+python scripts/generate_db_erd_svg.py \
+  --host 10.0.0.1 \
+  --user postgres \
+  --db revieu \
+  --password 123456 \
+  --output docs/database-erd.svg
+```
 
 ---
 

--- a/apps/core/cmd/app/main.go
+++ b/apps/core/cmd/app/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/config"
+	userservice "github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/user/service"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/router"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/pkg/database"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/pkg/logger"
@@ -74,6 +75,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	startAccountDeletionExecutor(ctx, userservice.NewUserService(database.DB))
+
 	// Initialize Gin router with JSON logging
 	gin.SetMode(gin.ReleaseMode)
 	router := buildRouter(cfg)
@@ -127,4 +130,27 @@ func jsonLoggerMiddleware() gin.HandlerFunc {
 			"user_agent", c.Request.UserAgent(),
 		)
 	}
+}
+
+func startAccountDeletionExecutor(ctx context.Context, svc *userservice.UserService) {
+	runOnce := func() {
+		processed, err := svc.ExecuteDueAccountDeletions(ctx, time.Now().UTC(), 0)
+		if err != nil {
+			logger.Error(ctx, "Failed to execute due account deletions", "error", err.Error())
+			return
+		}
+		if processed > 0 {
+			logger.Info(ctx, "Executed due account deletions", "processed", processed)
+		}
+	}
+
+	runOnce()
+
+	go func() {
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			runOnce()
+		}
+	}()
 }

--- a/apps/core/docs/docs.go
+++ b/apps/core/docs/docs.go
@@ -3161,7 +3161,7 @@ const docTemplate = `{
         },
         "/user/account": {
             "delete": {
-                "description": "Schedules account deletion (cooling period)",
+                "description": "Schedules account deletion (cooling period). Due deletions are executed asynchronously by a background worker.",
                 "consumes": [
                     "application/json"
                 ],

--- a/apps/core/docs/docs.go
+++ b/apps/core/docs/docs.go
@@ -1103,6 +1103,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/merchant/me": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Placeholder endpoint for future merchant deletion flow",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "merchant"
+                ],
+                "summary": "Delete current merchant (placeholder)",
+                "responses": {
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/merchant/stores": {
             "get": {
                 "security": [
@@ -1212,6 +1249,86 @@ const docTemplate = `{
             }
         },
         "/merchant/stores/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-deletes a merchant-owned store and its bound coupons",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "Delete a store",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
             "patch": {
                 "security": [
                     {
@@ -1457,6 +1574,95 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/merchant/stores/{id}/coupons/{couponId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-deletes a store-scoped coupon under an owned store",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "coupon"
+                ],
+                "summary": "Delete store coupon",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Coupon ID",
+                        "name": "couponId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -3351,7 +3557,8 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteListResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "401": {
@@ -3715,7 +3922,8 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostListResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "401": {
@@ -3967,7 +4175,8 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewListResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "401": {
@@ -4189,7 +4398,8 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostListResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "400": {
@@ -4248,7 +4458,8 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewListResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "400": {
@@ -4633,188 +4844,6 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteItem": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "merchant": {
-                    "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief"
-                },
-                "post": {
-                    "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostItem"
-                },
-                "review": {
-                    "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewItem"
-                },
-                "target_id": {
-                    "type": "integer"
-                },
-                "target_type": {
-                    "type": "string"
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteListResponse": {
-            "type": "object",
-            "properties": {
-                "cursor": {
-                    "type": "integer"
-                },
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteItem"
-                    }
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief": {
-            "type": "object",
-            "properties": {
-                "category": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostItem": {
-            "type": "object",
-            "properties": {
-                "content": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "images": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "is_liked": {
-                    "type": "boolean"
-                },
-                "like_count": {
-                    "type": "integer"
-                },
-                "merchant": {
-                    "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "title": {
-                    "type": "string"
-                },
-                "view_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostListResponse": {
-            "type": "object",
-            "properties": {
-                "cursor": {
-                    "type": "integer"
-                },
-                "posts": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostItem"
-                    }
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewItem": {
-            "type": "object",
-            "properties": {
-                "avg_cost": {
-                    "type": "integer"
-                },
-                "content": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "images": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "is_liked": {
-                    "type": "boolean"
-                },
-                "like_count": {
-                    "type": "integer"
-                },
-                "merchant": {
-                    "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief"
-                },
-                "rating": {
-                    "type": "number"
-                },
-                "rating_env": {
-                    "type": "number"
-                },
-                "rating_service": {
-                    "type": "number"
-                },
-                "rating_value": {
-                    "type": "number"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewListResponse": {
-            "type": "object",
-            "properties": {
-                "cursor": {
-                    "type": "integer"
-                },
-                "reviews": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewItem"
-                    }
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
         "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.FileRequest": {
             "type": "object",
             "properties": {

--- a/apps/core/docs/swagger.json
+++ b/apps/core/docs/swagger.json
@@ -3159,7 +3159,7 @@
         },
         "/user/account": {
             "delete": {
-                "description": "Schedules account deletion (cooling period)",
+                "description": "Schedules account deletion (cooling period). Due deletions are executed asynchronously by a background worker.",
                 "consumes": [
                     "application/json"
                 ],

--- a/apps/core/docs/swagger.json
+++ b/apps/core/docs/swagger.json
@@ -1101,6 +1101,43 @@
                 }
             }
         },
+        "/merchant/me": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Placeholder endpoint for future merchant deletion flow",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "merchant"
+                ],
+                "summary": "Delete current merchant (placeholder)",
+                "responses": {
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/merchant/stores": {
             "get": {
                 "security": [
@@ -1210,6 +1247,86 @@
             }
         },
         "/merchant/stores/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-deletes a merchant-owned store and its bound coupons",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "store"
+                ],
+                "summary": "Delete a store",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
             "patch": {
                 "security": [
                     {
@@ -1455,6 +1572,95 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/merchant/stores/{id}/coupons/{couponId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-deletes a store-scoped coupon under an owned store",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "coupon"
+                ],
+                "summary": "Delete store coupon",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Store ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Coupon ID",
+                        "name": "couponId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -3349,7 +3555,8 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteListResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "401": {
@@ -3713,7 +3920,8 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostListResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "401": {
@@ -3965,7 +4173,8 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewListResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "401": {
@@ -4187,7 +4396,8 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostListResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "400": {
@@ -4246,7 +4456,8 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewListResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "400": {
@@ -4631,188 +4842,6 @@
         }
     },
     "definitions": {
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteItem": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "merchant": {
-                    "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief"
-                },
-                "post": {
-                    "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostItem"
-                },
-                "review": {
-                    "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewItem"
-                },
-                "target_id": {
-                    "type": "integer"
-                },
-                "target_type": {
-                    "type": "string"
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteListResponse": {
-            "type": "object",
-            "properties": {
-                "cursor": {
-                    "type": "integer"
-                },
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteItem"
-                    }
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief": {
-            "type": "object",
-            "properties": {
-                "category": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostItem": {
-            "type": "object",
-            "properties": {
-                "content": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "images": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "is_liked": {
-                    "type": "boolean"
-                },
-                "like_count": {
-                    "type": "integer"
-                },
-                "merchant": {
-                    "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "title": {
-                    "type": "string"
-                },
-                "view_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostListResponse": {
-            "type": "object",
-            "properties": {
-                "cursor": {
-                    "type": "integer"
-                },
-                "posts": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostItem"
-                    }
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewItem": {
-            "type": "object",
-            "properties": {
-                "avg_cost": {
-                    "type": "integer"
-                },
-                "content": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "images": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "is_liked": {
-                    "type": "boolean"
-                },
-                "like_count": {
-                    "type": "integer"
-                },
-                "merchant": {
-                    "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief"
-                },
-                "rating": {
-                    "type": "number"
-                },
-                "rating_env": {
-                    "type": "number"
-                },
-                "rating_service": {
-                    "type": "number"
-                },
-                "rating_value": {
-                    "type": "number"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewListResponse": {
-            "type": "object",
-            "properties": {
-                "cursor": {
-                    "type": "integer"
-                },
-                "reviews": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewItem"
-                    }
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
         "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.FileRequest": {
             "type": "object",
             "properties": {

--- a/apps/core/docs/swagger.yaml
+++ b/apps/core/docs/swagger.yaml
@@ -2587,7 +2587,8 @@ paths:
     delete:
       consumes:
       - application/json
-      description: Schedules account deletion (cooling period)
+      description: Schedules account deletion (cooling period). Due deletions are
+        executed asynchronously by a background worker.
       parameters:
       - description: Deletion reason
         in: body

--- a/apps/core/docs/swagger.yaml
+++ b/apps/core/docs/swagger.yaml
@@ -1,124 +1,5 @@
 basePath: /api/v1
 definitions:
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteItem:
-    properties:
-      created_at:
-        type: string
-      id:
-        type: integer
-      merchant:
-        $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief'
-      post:
-        $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostItem'
-      review:
-        $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewItem'
-      target_id:
-        type: integer
-      target_type:
-        type: string
-    type: object
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteListResponse:
-    properties:
-      cursor:
-        type: integer
-      items:
-        items:
-          $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteItem'
-        type: array
-      total:
-        type: integer
-    type: object
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief:
-    properties:
-      category:
-        type: string
-      id:
-        type: integer
-      name:
-        type: string
-    type: object
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostItem:
-    properties:
-      content:
-        type: string
-      created_at:
-        type: string
-      id:
-        type: integer
-      images:
-        items:
-          type: string
-        type: array
-      is_liked:
-        type: boolean
-      like_count:
-        type: integer
-      merchant:
-        $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief'
-      tags:
-        items:
-          type: string
-        type: array
-      title:
-        type: string
-      view_count:
-        type: integer
-    type: object
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostListResponse:
-    properties:
-      cursor:
-        type: integer
-      posts:
-        items:
-          $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostItem'
-        type: array
-      total:
-        type: integer
-    type: object
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewItem:
-    properties:
-      avg_cost:
-        type: integer
-      content:
-        type: string
-      created_at:
-        type: string
-      id:
-        type: integer
-      images:
-        items:
-          type: string
-        type: array
-      is_liked:
-        type: boolean
-      like_count:
-        type: integer
-      merchant:
-        $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.MerchantBrief'
-      rating:
-        type: number
-      rating_env:
-        type: number
-      rating_service:
-        type: number
-      rating_value:
-        type: number
-      tags:
-        items:
-          type: string
-        type: array
-    type: object
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewListResponse:
-    properties:
-      cursor:
-        type: integer
-      reviews:
-        items:
-          $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewItem'
-        type: array
-      total:
-        type: integer
-    type: object
   github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.FileRequest:
     properties:
       content_type:
@@ -1350,6 +1231,29 @@ paths:
       summary: Create media upload
       tags:
       - media
+  /merchant/me:
+    delete:
+      description: Placeholder endpoint for future merchant deletion flow
+      produces:
+      - application/json
+      responses:
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "501":
+          description: Not Implemented
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete current merchant (placeholder)
+      tags:
+      - merchant
   /merchant/stores:
     get:
       description: Returns stores owned by the authenticated merchant user
@@ -1420,6 +1324,58 @@ paths:
       tags:
       - store
   /merchant/stores/{id}:
+    delete:
+      description: Soft-deletes a merchant-owned store and its bound coupons
+      parameters:
+      - description: Store ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete a store
+      tags:
+      - store
     patch:
       consumes:
       - application/json
@@ -1583,6 +1539,64 @@ paths:
       security:
       - BearerAuth: []
       summary: Create store coupon
+      tags:
+      - coupon
+  /merchant/stores/{id}/coupons/{couponId}:
+    delete:
+      description: Soft-deletes a store-scoped coupon under an owned store
+      parameters:
+      - description: Store ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Coupon ID
+        in: path
+        name: couponId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete store coupon
       tags:
       - coupon
   /merchant/stores/{id}/deactivate:
@@ -2831,7 +2845,8 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.FavoriteListResponse'
+            additionalProperties: true
+            type: object
         "401":
           description: Unauthorized
           schema:
@@ -3071,7 +3086,8 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostListResponse'
+            additionalProperties: true
+            type: object
         "401":
           description: Unauthorized
           schema:
@@ -3237,7 +3253,8 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewListResponse'
+            additionalProperties: true
+            type: object
         "401":
           description: Unauthorized
           schema:
@@ -3384,7 +3401,8 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.PostListResponse'
+            additionalProperties: true
+            type: object
         "400":
           description: Bad Request
           schema:
@@ -3423,7 +3441,8 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_content_dto.ReviewListResponse'
+            additionalProperties: true
+            type: object
         "400":
           description: Bad Request
           schema:

--- a/apps/core/internal/domain/ai/handler/ai.go
+++ b/apps/core/internal/domain/ai/handler/ai.go
@@ -11,11 +11,18 @@ type AIHandler struct {
 	svc *service.AIService
 }
 
-// SuggestionsRequest is a local alias for Swagger schema generation.
-type SuggestionsRequest = service.SuggestionsRequest
+// SuggestionsRequest is the request body for generating suggestions.
+type SuggestionsRequest struct {
+	OverallRating    float64 `json:"overallRating"`
+	BusinessCategory string  `json:"businessCategory"`
+	CurrentText      string  `json:"currentText"`
+	MerchantName     string  `json:"merchantName"`
+}
 
-// SuggestionsResponse is a local alias for Swagger schema generation.
-type SuggestionsResponse = service.SuggestionsResponse
+// SuggestionsResponse is the response body for generated suggestions.
+type SuggestionsResponse struct {
+	Suggestions []string `json:"suggestions"`
+}
 
 func NewAIHandler(svc *service.AIService) *AIHandler {
 	return &AIHandler{svc: svc}
@@ -33,11 +40,16 @@ func NewAIHandler(svc *service.AIService) *AIHandler {
 // @Failure 401 {object} map[string]string
 // @Router /ai/reviews/suggestions [post]
 func (h *AIHandler) Suggestions(c *gin.Context) {
-	var req service.SuggestionsRequest
+	var req SuggestionsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	resp := h.svc.Suggestions(req)
-	c.JSON(http.StatusOK, resp)
+	resp := h.svc.Suggestions(service.SuggestionsRequest{
+		OverallRating:    req.OverallRating,
+		BusinessCategory: req.BusinessCategory,
+		CurrentText:      req.CurrentText,
+		MerchantName:     req.MerchantName,
+	})
+	c.JSON(http.StatusOK, SuggestionsResponse{Suggestions: resp.Suggestions})
 }

--- a/apps/core/internal/domain/content/handler/favorite.go
+++ b/apps/core/internal/domain/content/handler/favorite.go
@@ -29,7 +29,7 @@ func NewFavoriteHandler(svc *service.ContentService) *FavoriteHandler {
 // @Param type query string false "Target type (post|review|merchant)"
 // @Param cursor query int false "Cursor"
 // @Param limit query int false "Limit"
-// @Success 200 {object} dto.FavoriteListResponse
+// @Success 200 {object} map[string]interface{}
 // @Failure 401 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /user/favorites [get]

--- a/apps/core/internal/domain/content/handler/post.go
+++ b/apps/core/internal/domain/content/handler/post.go
@@ -28,7 +28,7 @@ func NewPostHandler(svc *service.ContentService) *PostHandler {
 // @Param id path int true "User ID"
 // @Param cursor query int false "Cursor"
 // @Param limit query int false "Limit"
-// @Success 200 {object} dto.PostListResponse
+// @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /users/{id}/posts [get]
@@ -74,7 +74,7 @@ func (h *PostHandler) ListUserPosts(c *gin.Context) {
 // @Produce json
 // @Param cursor query int false "Cursor"
 // @Param limit query int false "Limit"
-// @Success 200 {object} dto.PostListResponse
+// @Success 200 {object} map[string]interface{}
 // @Failure 401 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /user/posts [get]

--- a/apps/core/internal/domain/content/handler/review.go
+++ b/apps/core/internal/domain/content/handler/review.go
@@ -28,7 +28,7 @@ func NewReviewHandler(svc *service.ContentService) *ReviewHandler {
 // @Param id path int true "User ID"
 // @Param cursor query int false "Cursor"
 // @Param limit query int false "Limit"
-// @Success 200 {object} dto.ReviewListResponse
+// @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /users/{id}/reviews [get]
@@ -78,7 +78,7 @@ func (h *ReviewHandler) ListUserReviews(c *gin.Context) {
 // @Produce json
 // @Param cursor query int false "Cursor"
 // @Param limit query int false "Limit"
-// @Success 200 {object} dto.ReviewListResponse
+// @Success 200 {object} map[string]interface{}
 // @Failure 401 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /user/reviews [get]

--- a/apps/core/internal/domain/coupon/handler/coupon.go
+++ b/apps/core/internal/domain/coupon/handler/coupon.go
@@ -98,6 +98,48 @@ func (h *CouponHandler) CreateStoreCoupon(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{"data": coupon})
 }
 
+// DeleteStoreCoupon godoc
+// @Summary Delete store coupon
+// @Description Soft-deletes a store-scoped coupon under an owned store
+// @Tags coupon
+// @Produce json
+// @Param id path int true "Store ID"
+// @Param couponId path int true "Coupon ID"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 403 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /merchant/stores/{id}/coupons/{couponId} [delete]
+func (h *CouponHandler) DeleteStoreCoupon(c *gin.Context) {
+	userID := c.GetInt64("user_id")
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	storeID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+	couponID, err := strconv.ParseInt(c.Param("couponId"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid coupon id"})
+		return
+	}
+
+	if err := h.svc.DeleteForStore(c.Request.Context(), userID, storeID, couponID); err != nil {
+		status, msg := couponErrorStatus(err)
+		c.JSON(status, gin.H{"error": msg})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
 // ListStoreCoupons godoc
 // @Summary List store coupons
 // @Description Lists published active coupons under a store

--- a/apps/core/internal/domain/coupon/routes.go
+++ b/apps/core/internal/domain/coupon/routes.go
@@ -28,6 +28,7 @@ func RegisterRoutes(r *gin.RouterGroup, cfg *config.Config) {
 	merchantStores := r.Group("/merchant/stores", middleware.JWTAuth(cfg.JWT))
 	{
 		merchantStores.POST("/:id/coupons", h.CreateStoreCoupon)
+		merchantStores.DELETE("/:id/coupons/:couponId", h.DeleteStoreCoupon)
 	}
 
 	packages := r.Group("/packages")

--- a/apps/core/internal/domain/coupon/service/service.go
+++ b/apps/core/internal/domain/coupon/service/service.go
@@ -141,6 +141,43 @@ func (s *CouponService) CreateForStore(ctx context.Context, userID, storeID int6
 	return &coupon, nil
 }
 
+func (s *CouponService) DeleteForStore(ctx context.Context, userID, storeID, couponID int64) error {
+	var merchant model.Merchant
+	if err := s.db.WithContext(ctx).Where("user_id = ?", userID).First(&merchant).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrStoreForbidden
+		}
+		return err
+	}
+
+	var store model.Store
+	if err := s.db.WithContext(ctx).First(&store, storeID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrStoreNotFound
+		}
+		return err
+	}
+	if store.MerchantID != merchant.ID {
+		return ErrStoreForbidden
+	}
+
+	var coupon model.Coupon
+	if err := s.db.WithContext(ctx).Unscoped().First(&coupon, couponID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrCouponNotFound
+		}
+		return err
+	}
+	if coupon.StoreID == nil || *coupon.StoreID != storeID || coupon.MerchantID != merchant.ID {
+		return ErrCouponNotFound
+	}
+	if coupon.DeletedAt.Valid {
+		return nil
+	}
+
+	return s.db.WithContext(ctx).Where("id = ?", couponID).Delete(&model.Coupon{}).Error
+}
+
 func (s *CouponService) ListPublishedByStore(ctx context.Context, storeID int64) ([]model.Coupon, error) {
 	if _, err := s.ensurePublishedStore(ctx, storeID); err != nil {
 		if errors.Is(err, ErrStoreNotPublished) {

--- a/apps/core/internal/domain/coupon/service/service_test.go
+++ b/apps/core/internal/domain/coupon/service/service_test.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupCouponTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+
+	if err := db.AutoMigrate(
+		&model.User{},
+		&model.Merchant{},
+		&model.Store{},
+		&model.Coupon{},
+	); err != nil {
+		t.Fatalf("failed to migrate test db: %v", err)
+	}
+
+	return db
+}
+
+func TestCouponServiceDeleteForStoreOwnerSoftDeleteAndIdempotent(t *testing.T) {
+	db := setupCouponTestDB(t)
+	svc := NewCouponService(db)
+
+	ownerID := int64(801)
+	if err := db.Create(&model.User{ID: ownerID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create owner user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &ownerID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Published Store", Status: storeStatusPublished}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	storeID := store.ID
+	coupon := model.Coupon{
+		MerchantID:    merchant.ID,
+		StoreID:       &storeID,
+		Title:         "Delete Coupon",
+		Type:          "cash",
+		TotalQuantity: 10,
+		MaxPerUser:    1,
+		Status:        couponStatusActive,
+	}
+	if err := db.Create(&coupon).Error; err != nil {
+		t.Fatalf("failed to create coupon: %v", err)
+	}
+
+	if err := svc.DeleteForStore(context.Background(), ownerID, store.ID, coupon.ID); err != nil {
+		t.Fatalf("delete coupon returned error: %v", err)
+	}
+
+	if err := svc.DeleteForStore(context.Background(), ownerID, store.ID, coupon.ID); err != nil {
+		t.Fatalf("second delete should be idempotent, got error: %v", err)
+	}
+
+	var liveCoupon model.Coupon
+	if err := db.First(&liveCoupon, coupon.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected scoped coupon query to hide deleted row, got err=%v", err)
+	}
+
+	var deletedCoupon model.Coupon
+	if err := db.Unscoped().First(&deletedCoupon, coupon.ID).Error; err != nil {
+		t.Fatalf("failed to query deleted coupon unscoped: %v", err)
+	}
+	if !deletedCoupon.DeletedAt.Valid {
+		t.Fatalf("expected deleted coupon to have deleted_at set")
+	}
+}
+
+func TestCouponServiceDeleteForStoreForbiddenForNonOwner(t *testing.T) {
+	db := setupCouponTestDB(t)
+	svc := NewCouponService(db)
+
+	ownerID := int64(811)
+	otherID := int64(812)
+	for _, id := range []int64{ownerID, otherID} {
+		if err := db.Create(&model.User{ID: id, Role: "user", Status: 0}).Error; err != nil {
+			t.Fatalf("failed to create user %d: %v", id, err)
+		}
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &ownerID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Owned Store", Status: storeStatusPublished}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	storeID := store.ID
+	coupon := model.Coupon{
+		MerchantID:    merchant.ID,
+		StoreID:       &storeID,
+		Title:         "Protected Coupon",
+		Type:          "cash",
+		TotalQuantity: 10,
+		MaxPerUser:    1,
+		Status:        couponStatusActive,
+	}
+	if err := db.Create(&coupon).Error; err != nil {
+		t.Fatalf("failed to create coupon: %v", err)
+	}
+
+	err := svc.DeleteForStore(context.Background(), otherID, store.ID, coupon.ID)
+	if !errors.Is(err, ErrStoreForbidden) {
+		t.Fatalf("expected ErrStoreForbidden, got %v", err)
+	}
+}
+
+func TestCouponServiceDeleteForStoreRejectsCouponOutsideStore(t *testing.T) {
+	db := setupCouponTestDB(t)
+	svc := NewCouponService(db)
+
+	ownerID := int64(821)
+	if err := db.Create(&model.User{ID: ownerID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create owner user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &ownerID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	storeA := model.Store{MerchantID: merchant.ID, Name: "Store A", Status: storeStatusPublished}
+	storeB := model.Store{MerchantID: merchant.ID, Name: "Store B", Status: storeStatusPublished}
+	if err := db.Create(&storeA).Error; err != nil {
+		t.Fatalf("failed to create store A: %v", err)
+	}
+	if err := db.Create(&storeB).Error; err != nil {
+		t.Fatalf("failed to create store B: %v", err)
+	}
+	storeBID := storeB.ID
+	coupon := model.Coupon{
+		MerchantID:    merchant.ID,
+		StoreID:       &storeBID,
+		Title:         "Store B Coupon",
+		Type:          "cash",
+		TotalQuantity: 10,
+		MaxPerUser:    1,
+		Status:        couponStatusActive,
+	}
+	if err := db.Create(&coupon).Error; err != nil {
+		t.Fatalf("failed to create coupon: %v", err)
+	}
+
+	err := svc.DeleteForStore(context.Background(), ownerID, storeA.ID, coupon.ID)
+	if !errors.Is(err, ErrCouponNotFound) {
+		t.Fatalf("expected ErrCouponNotFound for coupon-store mismatch, got %v", err)
+	}
+}

--- a/apps/core/internal/domain/merchant/handler/merchant.go
+++ b/apps/core/internal/domain/merchant/handler/merchant.go
@@ -100,3 +100,16 @@ func (h *MerchantHandler) Reviews(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"data": reviewdto.FromModels(reviews)})
 }
+
+// DeleteMerchantMe godoc
+// @Summary Delete current merchant (placeholder)
+// @Description Placeholder endpoint for future merchant deletion flow
+// @Tags merchant
+// @Produce json
+// @Success 501 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Security BearerAuth
+// @Router /merchant/me [delete]
+func (h *MerchantHandler) DeleteMe(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, gin.H{"error": "not implemented"})
+}

--- a/apps/core/internal/domain/merchant/handler/merchant_test.go
+++ b/apps/core/internal/domain/merchant/handler/merchant_test.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestMerchantHandlerDeleteMePlaceholder(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/api/v1/merchant/me", nil)
+
+	h := NewMerchantHandler(nil)
+	h.DeleteMe(c)
+
+	if recorder.Code != http.StatusNotImplemented {
+		t.Fatalf("expected status %d, got %d", http.StatusNotImplemented, recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), "not implemented") {
+		t.Fatalf("expected response body to mention not implemented, got %s", recorder.Body.String())
+	}
+}

--- a/apps/core/internal/domain/merchant/routes.go
+++ b/apps/core/internal/domain/merchant/routes.go
@@ -4,11 +4,12 @@ import (
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/config"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/merchant/handler"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/merchant/service"
+	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/middleware"
 	"github.com/gin-gonic/gin"
 )
 
 // RegisterRoutes registers merchant routes.
-func RegisterRoutes(r *gin.RouterGroup, _ *config.Config) {
+func RegisterRoutes(r *gin.RouterGroup, cfg *config.Config) {
 	svc := service.NewMerchantService(nil)
 	h := handler.NewMerchantHandler(svc)
 
@@ -17,5 +18,10 @@ func RegisterRoutes(r *gin.RouterGroup, _ *config.Config) {
 		merchants.GET("", h.List)
 		merchants.GET("/:id", h.Detail)
 		merchants.GET("/:id/reviews", h.Reviews)
+	}
+
+	merchantPrivate := r.Group("/merchant", middleware.JWTAuth(cfg.JWT))
+	{
+		merchantPrivate.DELETE("/me", h.DeleteMe)
 	}
 }

--- a/apps/core/internal/domain/store/handler/store.go
+++ b/apps/core/internal/domain/store/handler/store.go
@@ -347,6 +347,48 @@ func (h *StoreHandler) Deactivate(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
+// DeleteStore godoc
+// @Summary Delete a store
+// @Description Soft-deletes a merchant-owned store and its bound coupons
+// @Tags store
+// @Produce json
+// @Param id path int true "Store ID"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 403 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security BearerAuth
+// @Router /merchant/stores/{id} [delete]
+func (h *StoreHandler) Delete(c *gin.Context) {
+	userID := c.GetInt64("user_id")
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	storeID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store id"})
+		return
+	}
+
+	if err := h.svc.Delete(c.Request.Context(), userID, storeID); err != nil {
+		switch {
+		case errors.Is(err, service.ErrStoreNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		case errors.Is(err, service.ErrStoreForbidden):
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete store"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
 func parseStoreListQuery(c *gin.Context) (dto.StoreListQuery, error) {
 	var q dto.StoreListQuery
 

--- a/apps/core/internal/domain/store/routes.go
+++ b/apps/core/internal/domain/store/routes.go
@@ -28,5 +28,6 @@ func RegisterRoutes(r *gin.RouterGroup, cfg *config.Config) {
 		merchantStores.POST("/:id/activate", h.Activate)
 		merchantStores.POST("/:id/deactivate", h.Deactivate)
 		merchantStores.PATCH("/:id", h.Update)
+		merchantStores.DELETE("/:id", h.Delete)
 	}
 }

--- a/apps/core/internal/domain/store/service/service.go
+++ b/apps/core/internal/domain/store/service/service.go
@@ -304,6 +304,43 @@ func (s *StoreService) Deactivate(ctx context.Context, userID, storeID int64) er
 	return s.updateStatusOwned(ctx, userID, storeID, StoreStatusHidden)
 }
 
+func (s *StoreService) Delete(ctx context.Context, userID, storeID int64) error {
+	var merchant model.Merchant
+	if err := s.db.WithContext(ctx).Where("user_id = ?", userID).First(&merchant).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrStoreForbidden
+		}
+		return err
+	}
+
+	var store model.Store
+	if err := s.db.WithContext(ctx).Unscoped().First(&store, storeID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrStoreNotFound
+		}
+		return err
+	}
+	if store.MerchantID != merchant.ID {
+		return ErrStoreForbidden
+	}
+	if store.DeletedAt.Valid {
+		return nil
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("store_id = ?", storeID).Delete(&model.Coupon{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("id = ?", storeID).Delete(&model.Store{}).Error; err != nil {
+			return err
+		}
+		return tx.Model(&model.Merchant{}).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", merchant.ID).
+			UpdateColumn("total_stores", gorm.Expr("CASE WHEN total_stores > 0 THEN total_stores - 1 ELSE 0 END")).Error
+	})
+}
+
 func (s *StoreService) updateStatusOwned(ctx context.Context, userID, storeID int64, toStatus int16) error {
 	var merchant model.Merchant
 	if err := s.db.WithContext(ctx).Where("user_id = ?", userID).First(&merchant).Error; err != nil {

--- a/apps/core/internal/domain/store/service/service_test.go
+++ b/apps/core/internal/domain/store/service/service_test.go
@@ -30,6 +30,7 @@ func setupStoreTestDB(t *testing.T) *gorm.DB {
 		&model.Category{},
 		&model.StoreCategory{},
 		&model.Review{},
+		&model.Coupon{},
 	); err != nil {
 		t.Fatalf("failed to migrate test db: %v", err)
 	}
@@ -532,6 +533,120 @@ func TestStoreServiceDeactivateOwnStore(t *testing.T) {
 	}
 	if refreshed.Status != StoreStatusHidden {
 		t.Fatalf("unexpected status after deactivation: got %d, want %d", refreshed.Status, StoreStatusHidden)
+	}
+}
+
+func TestStoreServiceDeleteOwnStoreSoftDeletesStoreAndCoupons(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	userID := int64(3002)
+	if err := db.Create(&model.User{ID: userID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &userID, TotalStores: 2}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Store To Delete", Status: StoreStatusPublished}
+	otherStore := model.Store{MerchantID: merchant.ID, Name: "Store To Keep", Status: StoreStatusPublished}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	if err := db.Create(&otherStore).Error; err != nil {
+		t.Fatalf("failed to create other store: %v", err)
+	}
+	couponStoreID := store.ID
+	otherCouponStoreID := otherStore.ID
+	storeCoupon := model.Coupon{
+		MerchantID:    merchant.ID,
+		StoreID:       &couponStoreID,
+		Title:         "Delete Me",
+		Type:          "cash",
+		TotalQuantity: 10,
+		MaxPerUser:    1,
+		Status:        "active",
+	}
+	otherCoupon := model.Coupon{
+		MerchantID:    merchant.ID,
+		StoreID:       &otherCouponStoreID,
+		Title:         "Keep Me",
+		Type:          "cash",
+		TotalQuantity: 10,
+		MaxPerUser:    1,
+		Status:        "active",
+	}
+	if err := db.Create(&storeCoupon).Error; err != nil {
+		t.Fatalf("failed to create store coupon: %v", err)
+	}
+	if err := db.Create(&otherCoupon).Error; err != nil {
+		t.Fatalf("failed to create other coupon: %v", err)
+	}
+
+	if err := svc.Delete(context.Background(), userID, store.ID); err != nil {
+		t.Fatalf("delete returned error: %v", err)
+	}
+
+	var liveStore model.Store
+	if err := db.First(&liveStore, store.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected deleted store to be hidden from scoped query, got err=%v", err)
+	}
+	var deletedStore model.Store
+	if err := db.Unscoped().First(&deletedStore, store.ID).Error; err != nil {
+		t.Fatalf("failed to query deleted store unscoped: %v", err)
+	}
+	if !deletedStore.DeletedAt.Valid {
+		t.Fatalf("expected deleted store to have deleted_at set")
+	}
+
+	var liveCoupon model.Coupon
+	if err := db.First(&liveCoupon, storeCoupon.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected scoped coupon query to hide deleted coupon, got err=%v", err)
+	}
+	var deletedCoupon model.Coupon
+	if err := db.Unscoped().First(&deletedCoupon, storeCoupon.ID).Error; err != nil {
+		t.Fatalf("failed to query deleted coupon unscoped: %v", err)
+	}
+	if !deletedCoupon.DeletedAt.Valid {
+		t.Fatalf("expected deleted coupon to have deleted_at set")
+	}
+
+	if err := db.First(&liveCoupon, otherCoupon.ID).Error; err != nil {
+		t.Fatalf("expected coupon under another store to remain active, got err=%v", err)
+	}
+
+	var refreshedMerchant model.Merchant
+	if err := db.First(&refreshedMerchant, merchant.ID).Error; err != nil {
+		t.Fatalf("failed to reload merchant: %v", err)
+	}
+	if refreshedMerchant.TotalStores != 1 {
+		t.Fatalf("expected total_stores decremented to 1, got %d", refreshedMerchant.TotalStores)
+	}
+}
+
+func TestStoreServiceDeleteNonOwnerForbidden(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	ownerID := int64(3003)
+	otherID := int64(3004)
+	for _, id := range []int64{ownerID, otherID} {
+		if err := db.Create(&model.User{ID: id, Role: "user", Status: 0}).Error; err != nil {
+			t.Fatalf("failed to create user %d: %v", id, err)
+		}
+	}
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &ownerID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Protected Store", Status: StoreStatusPublished}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	err := svc.Delete(context.Background(), otherID, store.ID)
+	if !errors.Is(err, ErrStoreForbidden) {
+		t.Fatalf("expected ErrStoreForbidden, got %v", err)
 	}
 }
 

--- a/apps/core/internal/domain/user/handler/user.go
+++ b/apps/core/internal/domain/user/handler/user.go
@@ -425,7 +425,7 @@ func (h *UserHandler) RequestAccountExport(c *gin.Context) {
 
 // RequestAccountDeletion godoc
 // @Summary Request account deletion
-// @Description Schedules account deletion (cooling period)
+// @Description Schedules account deletion (cooling period). Due deletions are executed asynchronously by a background worker.
 // @Tags user
 // @Accept json
 // @Produce json

--- a/apps/core/internal/domain/user/service/user.go
+++ b/apps/core/internal/domain/user/service/user.go
@@ -9,11 +9,15 @@ import (
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/pkg/database"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type UserService struct {
 	db *gorm.DB
 }
+
+const accountDeletionDelay = 7 * 24 * time.Hour
+const defaultAccountDeletionBatchSize = 50
 
 func NewUserService(db *gorm.DB) *UserService {
 	if db == nil {
@@ -185,6 +189,92 @@ func (s *UserService) SetDefaultAddress(ctx context.Context, userID, addressID i
 }
 
 func (s *UserService) RequestAccountDeletion(ctx context.Context, userID int64, reason string) error {
-	deletion := model.AccountDeletion{UserID: userID, Reason: reason, ScheduledAt: time.Now().UTC().Add(7 * 24 * time.Hour)}
-	return s.db.WithContext(ctx).Save(&deletion).Error
+	deletion := model.AccountDeletion{
+		UserID:      userID,
+		Reason:      reason,
+		ScheduledAt: time.Now().UTC().Add(accountDeletionDelay),
+	}
+	return s.db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "user_id"}},
+			DoUpdates: clause.AssignmentColumns([]string{"reason", "scheduled_at"}),
+		}).
+		Create(&deletion).Error
+}
+
+func (s *UserService) ExecuteDueAccountDeletions(ctx context.Context, now time.Time, limit int) (int, error) {
+	if limit <= 0 {
+		limit = defaultAccountDeletionBatchSize
+	}
+
+	var due []model.AccountDeletion
+	if err := s.db.WithContext(ctx).
+		Where("scheduled_at <= ?", now).
+		Order("scheduled_at asc, id asc").
+		Limit(limit).
+		Find(&due).Error; err != nil {
+		return 0, err
+	}
+
+	processed := 0
+	for _, item := range due {
+		if err := s.executeAccountDeletion(ctx, item.UserID, now); err != nil {
+			return processed, err
+		}
+		processed++
+	}
+
+	return processed, nil
+}
+
+func (s *UserService) executeAccountDeletion(ctx context.Context, userID int64, now time.Time) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var deletion model.AccountDeletion
+		if err := tx.
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("user_id = ?", userID).
+			First(&deletion).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			return err
+		}
+
+		if deletion.ScheduledAt.After(now) {
+			return nil
+		}
+
+		var merchantIDs []int64
+		if err := tx.Model(&model.Merchant{}).
+			Where("user_id = ?", userID).
+			Pluck("id", &merchantIDs).Error; err != nil {
+			return err
+		}
+
+		if len(merchantIDs) > 0 {
+			if err := tx.Where("merchant_id IN ?", merchantIDs).Delete(&model.Coupon{}).Error; err != nil {
+				return err
+			}
+			if err := tx.Where("merchant_id IN ?", merchantIDs).Delete(&model.Store{}).Error; err != nil {
+				return err
+			}
+			if err := tx.Where("id IN ?", merchantIDs).Delete(&model.Merchant{}).Error; err != nil {
+				return err
+			}
+		}
+
+		// Some production DBs still include NO ACTION constraints from users->user_auths/profile.
+		// Remove dependents explicitly before deleting the user row.
+		if err := tx.Where("user_id = ?", userID).Delete(&model.UserAuth{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&model.UserProfile{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Delete(&model.User{}, userID).Error; err != nil {
+			return err
+		}
+
+		return tx.Where("user_id = ?", userID).Delete(&model.AccountDeletion{}).Error
+	})
 }

--- a/apps/core/internal/domain/user/service/user_test.go
+++ b/apps/core/internal/domain/user/service/user_test.go
@@ -2,11 +2,14 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	userdto "github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/user/dto"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/testutil"
+	"gorm.io/gorm"
 )
 
 func TestUserServiceProfileAndSettings(t *testing.T) {
@@ -42,5 +45,147 @@ func TestUserServiceAddressDefault(t *testing.T) {
 	addr, err := svc.CreateAddress(context.Background(), user.ID, userdto.CreateAddressRequest{Name: "A", Phone: "1", Address: "X"})
 	if err != nil || !addr.IsDefault {
 		t.Fatalf("expected default address")
+	}
+}
+
+func TestUserServiceExecuteDueAccountDeletionsCascadesMerchantData(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	svc := NewUserService(db)
+
+	user := model.User{Role: "user", Status: 0}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.UserAuth{
+		UserID:       user.ID,
+		IdentityType: "email",
+		Identifier:   "cascade-user@example.com",
+		Credential:   "pw",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.UserProfile{
+		UserID:   user.ID,
+		Nickname: "cascade-user",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	merchant := model.Merchant{Name: "Cascade Merchant", UserID: &user.ID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatal(err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Cascade Store", Status: 1}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatal(err)
+	}
+	storeID := store.ID
+	coupon := model.Coupon{
+		MerchantID:    merchant.ID,
+		StoreID:       &storeID,
+		Title:         "Cascade Coupon",
+		Type:          "single",
+		TotalQuantity: 1,
+		MaxPerUser:    1,
+		Status:        "published",
+	}
+	if err := db.Create(&coupon).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.AccountDeletion{
+		UserID:      user.ID,
+		Reason:      "cleanup test",
+		ScheduledAt: time.Now().UTC().Add(-1 * time.Minute),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	processed, err := svc.ExecuteDueAccountDeletions(context.Background(), time.Now().UTC(), 10)
+	if err != nil {
+		t.Fatalf("execute due deletions failed: %v", err)
+	}
+	if processed != 1 {
+		t.Fatalf("expected processed=1, got %d", processed)
+	}
+
+	if err := db.First(&model.User{}, user.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected user deleted, got err=%v", err)
+	}
+	if err := db.First(&model.UserAuth{}, "user_id = ?", user.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected user auth deleted, got err=%v", err)
+	}
+	if err := db.First(&model.UserProfile{}, "user_id = ?", user.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected user profile deleted, got err=%v", err)
+	}
+	if err := db.First(&model.AccountDeletion{}, "user_id = ?", user.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected account deletion row cleared, got err=%v", err)
+	}
+
+	if err := db.First(&model.Merchant{}, merchant.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected merchant hidden by soft delete, got err=%v", err)
+	}
+	if err := db.First(&model.Store{}, store.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected store hidden by soft delete, got err=%v", err)
+	}
+	if err := db.First(&model.Coupon{}, coupon.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected coupon hidden by soft delete, got err=%v", err)
+	}
+
+	var deletedMerchant model.Merchant
+	if err := db.Unscoped().First(&deletedMerchant, merchant.ID).Error; err != nil {
+		t.Fatalf("expected soft-deleted merchant to exist unscoped: %v", err)
+	}
+	if !deletedMerchant.DeletedAt.Valid {
+		t.Fatalf("expected merchant deleted_at to be set")
+	}
+	var deletedStore model.Store
+	if err := db.Unscoped().First(&deletedStore, store.ID).Error; err != nil {
+		t.Fatalf("expected soft-deleted store to exist unscoped: %v", err)
+	}
+	if !deletedStore.DeletedAt.Valid {
+		t.Fatalf("expected store deleted_at to be set")
+	}
+	var deletedCoupon model.Coupon
+	if err := db.Unscoped().First(&deletedCoupon, coupon.ID).Error; err != nil {
+		t.Fatalf("expected soft-deleted coupon to exist unscoped: %v", err)
+	}
+	if !deletedCoupon.DeletedAt.Valid {
+		t.Fatalf("expected coupon deleted_at to be set")
+	}
+}
+
+func TestUserServiceExecuteDueAccountDeletionsIsIdempotent(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	svc := NewUserService(db)
+
+	user := model.User{Role: "user", Status: 0}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.UserProfile{UserID: user.ID, Nickname: "retry"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.AccountDeletion{
+		UserID:      user.ID,
+		Reason:      "retry",
+		ScheduledAt: time.Now().UTC().Add(-1 * time.Minute),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	processed, err := svc.ExecuteDueAccountDeletions(context.Background(), time.Now().UTC(), 10)
+	if err != nil {
+		t.Fatalf("first execution failed: %v", err)
+	}
+	if processed != 1 {
+		t.Fatalf("expected first processed=1, got %d", processed)
+	}
+
+	processed, err = svc.ExecuteDueAccountDeletions(context.Background(), time.Now().UTC(), 10)
+	if err != nil {
+		t.Fatalf("second execution failed: %v", err)
+	}
+	if processed != 0 {
+		t.Fatalf("expected second processed=0, got %d", processed)
 	}
 }

--- a/apps/core/internal/domain/voucher/service/service.go
+++ b/apps/core/internal/domain/voucher/service/service.go
@@ -102,7 +102,7 @@ func (s *VoucherService) RedeemByMerchant(ctx context.Context, userID, voucherID
 		}
 
 		var coupon model.Coupon
-		if err := tx.First(&coupon, voucher.CouponID).Error; err != nil {
+		if err := tx.Unscoped().First(&coupon, voucher.CouponID).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrVoucherNotFound
 			}
@@ -133,7 +133,7 @@ func (s *VoucherService) RedeemByMerchant(ctx context.Context, userID, voucherID
 			return err
 		}
 
-		return tx.Model(&model.Coupon{}).
+		return tx.Unscoped().Model(&model.Coupon{}).
 			Where("id = ?", coupon.ID).
 			UpdateColumn("redeemed_count", gorm.Expr("redeemed_count + 1")).Error
 	})

--- a/apps/core/internal/domain/voucher/service/service_test.go
+++ b/apps/core/internal/domain/voucher/service/service_test.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupVoucherTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+
+	if err := db.AutoMigrate(
+		&model.User{},
+		&model.Merchant{},
+		&model.Store{},
+		&model.Coupon{},
+		&model.Voucher{},
+	); err != nil {
+		t.Fatalf("failed to migrate test db: %v", err)
+	}
+
+	return db
+}
+
+func TestVoucherServiceRedeemByMerchantAllowsSoftDeletedCoupon(t *testing.T) {
+	db := setupVoucherTestDB(t)
+	svc := NewVoucherService(db)
+
+	merchantUserID := int64(901)
+	customerUserID := int64(902)
+	for _, id := range []int64{merchantUserID, customerUserID} {
+		if err := db.Create(&model.User{ID: id, Role: "user", Status: 0}).Error; err != nil {
+			t.Fatalf("failed to create user %d: %v", id, err)
+		}
+	}
+
+	merchant := model.Merchant{Name: "Merchant Owner", UserID: &merchantUserID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Redeem Store", Status: 1}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	storeID := store.ID
+	coupon := model.Coupon{
+		MerchantID:    merchant.ID,
+		StoreID:       &storeID,
+		Title:         "Redeem Coupon",
+		Type:          "cash",
+		TotalQuantity: 100,
+		MaxPerUser:    1,
+		Status:        "active",
+	}
+	if err := db.Create(&coupon).Error; err != nil {
+		t.Fatalf("failed to create coupon: %v", err)
+	}
+
+	voucher := model.Voucher{
+		Code:       "voucher-soft-delete-test",
+		CouponID:   coupon.ID,
+		UserID:     customerUserID,
+		MerchantID: &merchant.ID,
+		Status:     "active",
+	}
+	if err := db.Create(&voucher).Error; err != nil {
+		t.Fatalf("failed to create voucher: %v", err)
+	}
+
+	if err := db.Delete(&coupon).Error; err != nil {
+		t.Fatalf("failed to soft-delete coupon: %v", err)
+	}
+
+	if err := svc.RedeemByMerchant(context.Background(), merchantUserID, voucher.ID); err != nil {
+		t.Fatalf("redeem by merchant returned error: %v", err)
+	}
+
+	var refreshedVoucher model.Voucher
+	if err := db.First(&refreshedVoucher, voucher.ID).Error; err != nil {
+		t.Fatalf("failed to reload voucher: %v", err)
+	}
+	if refreshedVoucher.Status != "used" {
+		t.Fatalf("expected voucher status used, got %q", refreshedVoucher.Status)
+	}
+	if refreshedVoucher.RedeemedBy == nil || *refreshedVoucher.RedeemedBy != merchantUserID {
+		t.Fatalf("expected redeemed_by=%d, got %+v", merchantUserID, refreshedVoucher.RedeemedBy)
+	}
+
+	var refreshedCoupon model.Coupon
+	if err := db.Unscoped().First(&refreshedCoupon, coupon.ID).Error; err != nil {
+		t.Fatalf("failed to reload coupon unscoped: %v", err)
+	}
+	if refreshedCoupon.RedeemedCount != 1 {
+		t.Fatalf("expected redeemed_count=1, got %d", refreshedCoupon.RedeemedCount)
+	}
+}

--- a/apps/core/internal/model/coupon.go
+++ b/apps/core/internal/model/coupon.go
@@ -1,33 +1,38 @@
 package model
 
-import "time"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type Coupon struct {
-	ID                 int64      `gorm:"primaryKey;autoIncrement" json:"id"`
-	MerchantID         int64      `gorm:"not null;index" json:"merchant_id"`
-	StoreID            *int64     `gorm:"index" json:"store_id"`
-	PackageID          *int64     `gorm:"index" json:"package_id"`
-	Title              string     `gorm:"type:varchar(100);not null" json:"title"`
-	Description        string     `gorm:"type:text" json:"description"`
-	ImageURL           string     `gorm:"type:varchar(255)" json:"image_url"`
-	Type               string     `gorm:"type:varchar(20);not null" json:"type"`
-	CouponType         string     `gorm:"type:varchar(20)" json:"coupon_type"`
-	Value              string     `gorm:"type:varchar(50)" json:"value"`
-	Price              float64    `json:"price"`
-	OriginalPrice      float64    `gorm:"type:numeric(10,2)" json:"original_price"`
-	SalePrice          float64    `gorm:"type:numeric(10,2)" json:"sale_price"`
-	DiscountPercentage float64    `gorm:"type:numeric(5,2)" json:"discount_percentage"`
-	TotalQuantity      int        `gorm:"default:0" json:"total_quantity"`
-	ClaimedCount       int        `gorm:"default:0" json:"claimed_count"`
-	RedeemedCount      int        `gorm:"default:0" json:"redeemed_count"`
-	MaxPerUser         int        `gorm:"default:1" json:"max_per_user"`
-	Terms              string     `gorm:"type:text" json:"terms"`
-	ExpiryDate         time.Time  `json:"expiry_date"`
-	ValidFrom          *time.Time `json:"valid_from"`
-	ValidUntil         *time.Time `json:"valid_until"`
-	Status             string     `gorm:"type:varchar(20);default:'active'" json:"status"`
-	CreatedAt          time.Time  `json:"created_at"`
-	UpdatedAt          time.Time  `json:"updated_at"`
+	ID                 int64          `gorm:"primaryKey;autoIncrement" json:"id"`
+	MerchantID         int64          `gorm:"not null;index" json:"merchant_id"`
+	StoreID            *int64         `gorm:"index" json:"store_id"`
+	PackageID          *int64         `gorm:"index" json:"package_id"`
+	Title              string         `gorm:"type:varchar(100);not null" json:"title"`
+	Description        string         `gorm:"type:text" json:"description"`
+	ImageURL           string         `gorm:"type:varchar(255)" json:"image_url"`
+	Type               string         `gorm:"type:varchar(20);not null" json:"type"`
+	CouponType         string         `gorm:"type:varchar(20)" json:"coupon_type"`
+	Value              string         `gorm:"type:varchar(50)" json:"value"`
+	Price              float64        `json:"price"`
+	OriginalPrice      float64        `gorm:"type:numeric(10,2)" json:"original_price"`
+	SalePrice          float64        `gorm:"type:numeric(10,2)" json:"sale_price"`
+	DiscountPercentage float64        `gorm:"type:numeric(5,2)" json:"discount_percentage"`
+	TotalQuantity      int            `gorm:"default:0" json:"total_quantity"`
+	ClaimedCount       int            `gorm:"default:0" json:"claimed_count"`
+	RedeemedCount      int            `gorm:"default:0" json:"redeemed_count"`
+	MaxPerUser         int            `gorm:"default:1" json:"max_per_user"`
+	Terms              string         `gorm:"type:text" json:"terms"`
+	ExpiryDate         time.Time      `json:"expiry_date"`
+	ValidFrom          *time.Time     `json:"valid_from"`
+	ValidUntil         *time.Time     `json:"valid_until"`
+	Status             string         `gorm:"type:varchar(20);default:'active'" json:"status"`
+	CreatedAt          time.Time      `json:"created_at"`
+	UpdatedAt          time.Time      `json:"updated_at"`
+	DeletedAt          gorm.DeletedAt `gorm:"index" json:"deleted_at,omitempty"`
 }
 
 func (c *Coupon) TableName() string { return "coupons" }

--- a/apps/core/internal/model/merchant.go
+++ b/apps/core/internal/model/merchant.go
@@ -1,33 +1,38 @@
 package model
 
-import "time"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type Merchant struct {
-	ID                 int64      `gorm:"primaryKey;autoIncrement" json:"id"`
-	UserID             *int64     `gorm:"index" json:"user_id"`
-	Name               string     `gorm:"type:varchar(100);not null" json:"name"`
-	BusinessName       string     `gorm:"type:varchar(100)" json:"business_name"`
-	BusinessType       string     `gorm:"type:varchar(50)" json:"business_type"`
-	Category           string     `gorm:"type:varchar(50)" json:"category"`
-	LogoURL            string     `gorm:"type:varchar(255)" json:"logo_url"`
-	Address            string     `gorm:"type:varchar(255)" json:"address"`
-	Phone              string     `gorm:"type:varchar(20)" json:"phone"`
-	ContactPhone       string     `gorm:"type:varchar(20)" json:"contact_phone"`
-	ContactEmail       string     `gorm:"type:varchar(255)" json:"contact_email"`
-	WebsiteURL         string     `gorm:"type:varchar(255)" json:"website_url"`
-	SocialLinks        string     `gorm:"type:jsonb;default:'{}'" json:"social_links"`
-	CoverImage         string     `gorm:"type:varchar(255)" json:"cover_image"`
-	Description        string     `gorm:"type:text" json:"description"`
-	AvgRating          float32    `gorm:"default:0" json:"avg_rating"`
-	ReviewCount        int        `gorm:"default:0" json:"review_count"`
-	FollowerCount      int        `gorm:"default:0" json:"follower_count"`
-	TotalStores        int        `gorm:"default:0" json:"total_stores"`
-	TotalReviews       int        `gorm:"default:0" json:"total_reviews"`
-	VerificationStatus string     `gorm:"type:varchar(20);default:'unverified'" json:"verification_status"`
-	VerifiedAt         *time.Time `json:"verified_at"`
-	Status             int16      `gorm:"default:0" json:"status"`
-	CreatedAt          time.Time  `json:"created_at"`
-	UpdatedAt          time.Time  `json:"updated_at"`
+	ID                 int64          `gorm:"primaryKey;autoIncrement" json:"id"`
+	UserID             *int64         `gorm:"index" json:"user_id"`
+	Name               string         `gorm:"type:varchar(100);not null" json:"name"`
+	BusinessName       string         `gorm:"type:varchar(100)" json:"business_name"`
+	BusinessType       string         `gorm:"type:varchar(50)" json:"business_type"`
+	Category           string         `gorm:"type:varchar(50)" json:"category"`
+	LogoURL            string         `gorm:"type:varchar(255)" json:"logo_url"`
+	Address            string         `gorm:"type:varchar(255)" json:"address"`
+	Phone              string         `gorm:"type:varchar(20)" json:"phone"`
+	ContactPhone       string         `gorm:"type:varchar(20)" json:"contact_phone"`
+	ContactEmail       string         `gorm:"type:varchar(255)" json:"contact_email"`
+	WebsiteURL         string         `gorm:"type:varchar(255)" json:"website_url"`
+	SocialLinks        string         `gorm:"type:jsonb;default:'{}'" json:"social_links"`
+	CoverImage         string         `gorm:"type:varchar(255)" json:"cover_image"`
+	Description        string         `gorm:"type:text" json:"description"`
+	AvgRating          float32        `gorm:"default:0" json:"avg_rating"`
+	ReviewCount        int            `gorm:"default:0" json:"review_count"`
+	FollowerCount      int            `gorm:"default:0" json:"follower_count"`
+	TotalStores        int            `gorm:"default:0" json:"total_stores"`
+	TotalReviews       int            `gorm:"default:0" json:"total_reviews"`
+	VerificationStatus string         `gorm:"type:varchar(20);default:'unverified'" json:"verification_status"`
+	VerifiedAt         *time.Time     `json:"verified_at"`
+	Status             int16          `gorm:"default:0" json:"status"`
+	CreatedAt          time.Time      `json:"created_at"`
+	UpdatedAt          time.Time      `json:"updated_at"`
+	DeletedAt          gorm.DeletedAt `gorm:"index" json:"deleted_at,omitempty"`
 
 	User   *User   `gorm:"foreignKey:UserID" json:"user,omitempty"`
 	Stores []Store `gorm:"foreignKey:MerchantID" json:"stores,omitempty"`

--- a/apps/core/internal/model/store.go
+++ b/apps/core/internal/model/store.go
@@ -1,29 +1,34 @@
 package model
 
-import "time"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type Store struct {
-	ID            int64     `gorm:"primaryKey;autoIncrement" json:"id"`
-	MerchantID    int64     `gorm:"not null;index" json:"merchant_id"`
-	Name          string    `gorm:"type:varchar(255);not null" json:"name"`
-	Description   string    `gorm:"type:text" json:"description"`
-	Address       string    `gorm:"type:varchar(255)" json:"address"`
-	City          string    `gorm:"type:varchar(100)" json:"city"`
-	State         string    `gorm:"type:varchar(100)" json:"state"`
-	ZipCode       string    `gorm:"type:varchar(20)" json:"zip_code"`
-	Country       string    `gorm:"type:varchar(50)" json:"country"`
-	Phone         string    `gorm:"type:varchar(50)" json:"phone"`
-	Website       string    `gorm:"type:varchar(255)" json:"website"`
-	Latitude      float64   `json:"latitude"`
-	Longitude     float64   `json:"longitude"`
-	CoverImageURL string    `gorm:"type:varchar(255)" json:"cover_image_url"`
-	Images        string    `gorm:"type:jsonb;default:'[]'" json:"images"`
-	AvgRating     float32   `gorm:"default:0" json:"avg_rating"`
-	ReviewCount   int       `gorm:"default:0" json:"review_count"`
-	FollowerCount int       `gorm:"default:0" json:"follower_count"`
-	Status        int16     `gorm:"default:0" json:"status"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
+	ID            int64          `gorm:"primaryKey;autoIncrement" json:"id"`
+	MerchantID    int64          `gorm:"not null;index" json:"merchant_id"`
+	Name          string         `gorm:"type:varchar(255);not null" json:"name"`
+	Description   string         `gorm:"type:text" json:"description"`
+	Address       string         `gorm:"type:varchar(255)" json:"address"`
+	City          string         `gorm:"type:varchar(100)" json:"city"`
+	State         string         `gorm:"type:varchar(100)" json:"state"`
+	ZipCode       string         `gorm:"type:varchar(20)" json:"zip_code"`
+	Country       string         `gorm:"type:varchar(50)" json:"country"`
+	Phone         string         `gorm:"type:varchar(50)" json:"phone"`
+	Website       string         `gorm:"type:varchar(255)" json:"website"`
+	Latitude      float64        `json:"latitude"`
+	Longitude     float64        `json:"longitude"`
+	CoverImageURL string         `gorm:"type:varchar(255)" json:"cover_image_url"`
+	Images        string         `gorm:"type:jsonb;default:'[]'" json:"images"`
+	AvgRating     float32        `gorm:"default:0" json:"avg_rating"`
+	ReviewCount   int            `gorm:"default:0" json:"review_count"`
+	FollowerCount int            `gorm:"default:0" json:"follower_count"`
+	Status        int16          `gorm:"default:0" json:"status"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"deleted_at,omitempty"`
 
 	Merchant   *Merchant   `gorm:"foreignKey:MerchantID" json:"merchant,omitempty"`
 	Categories []Category  `gorm:"many2many:store_categories" json:"categories,omitempty"`

--- a/apps/core/migrations/00002_add_soft_delete_to_merchant_store_coupon.sql
+++ b/apps/core/migrations/00002_add_soft_delete_to_merchant_store_coupon.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+
+ALTER TABLE merchants ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_merchants_deleted_at ON merchants (deleted_at);
+
+ALTER TABLE stores ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_stores_deleted_at ON stores (deleted_at);
+
+ALTER TABLE coupons ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_coupons_deleted_at ON coupons (deleted_at);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_coupons_deleted_at;
+ALTER TABLE coupons DROP COLUMN IF EXISTS deleted_at;
+
+DROP INDEX IF EXISTS idx_stores_deleted_at;
+ALTER TABLE stores DROP COLUMN IF EXISTS deleted_at;
+
+DROP INDEX IF EXISTS idx_merchants_deleted_at;
+ALTER TABLE merchants DROP COLUMN IF EXISTS deleted_at;

--- a/docs/database-erd.svg
+++ b/docs/database-erd.svg
@@ -1,0 +1,664 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2660" height="3108" viewBox="0 0 2660 3108">
+<defs><marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L9,3 z" fill="#64748b" /></marker></defs>
+<rect x="0" y="0" width="2660" height="3108" fill="#f8fafc" />
+<text x="40" y="40" font-family="Arial, sans-serif" font-size="24" font-weight="700" fill="#0f172a">RevieU Database ERD (public schema)</text>
+<text x="40" y="66" font-family="Arial, sans-serif" font-size="13" fill="#334155">Tables: 44 | FK relationships: 79 | PK/FK markers shown per column</text>
+<text x="40" y="88" font-family="Arial, sans-serif" font-size="12" fill="#334155">Legend: [PK] primary key, [FK] foreign key, "?" nullable column</text>
+<path d="M 255.0 284.0 C 255.0 1548.0, 255.0 1548.0, 255.0 2812.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>account_deletions.user_id -&gt; users.id (account_deletions_user_id_fkey)</title></path>
+<path d="M 544.0 203.0 C 544.0 1531.0, 396.0 1531.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>admin_audit_logs.admin_id -&gt; users.id (admin_audit_logs_admin_id_fkey)</title></path>
+<path d="M 974.0 251.0 C 974.0 987.0, 409.0 987.0, 409.0 1723.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>browsing_histories.post_id -&gt; posts.id (browsing_histories_post_id_fkey)</title></path>
+<path d="M 974.0 235.0 C 974.0 1159.0, 839.0 1159.0, 839.0 2083.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>browsing_histories.review_id -&gt; reviews.id (browsing_histories_review_id_fkey)</title></path>
+<path d="M 1256.0 219.0 C 1256.0 1139.0, 1820.0 1139.0, 1820.0 2059.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>browsing_histories.store_id -&gt; stores.id (browsing_histories_store_id_fkey)</title></path>
+<path d="M 974.0 203.0 C 974.0 1531.0, 396.0 1531.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>browsing_histories.user_id -&gt; users.id (browsing_histories_user_id_fkey)</title></path>
+<path d="M 1545.0 164.0 C 1545.0 220.0, 1545.0 220.0, 1545.0 276.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>categories.parent_id -&gt; categories.id (categories_parent_id_fkey)</title></path>
+<path d="M 2157.0 203.0 C 2210.5 203.0, 2210.5 203.0, 2264.0 203.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>conversation_participants.conversation_id -&gt; conversations.id (conversation_participants_conversation_id_fkey)</title></path>
+<path d="M 1793.0 219.0 C 1793.0 1539.0, 396.0 1539.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>conversation_participants.user_id -&gt; users.id (conversation_participants_user_id_fkey)</title></path>
+<path d="M 409.0 395.0 C 1111.0 395.0, 1111.0 875.0, 1813.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>coupons.merchant_id -&gt; merchants.id (coupons_merchant_id_fkey)</title></path>
+<path d="M 409.0 427.0 C 409.0 899.0, 960.0 899.0, 960.0 1371.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>coupons.package_id -&gt; packages.id (coupons_package_id_fkey)</title></path>
+<path d="M 409.0 411.0 C 409.0 1235.0, 1820.0 1235.0, 1820.0 2059.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>coupons.store_id -&gt; stores.id (coupons_store_id_fkey)</title></path>
+<path d="M 544.0 555.0 C 544.0 1707.0, 396.0 1707.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>email_verifications.user_id -&gt; users.id (email_verifications_user_id_fkey)</title></path>
+<path d="M 2250.0 579.0 C 1329.5 579.0, 1329.5 379.0, 409.0 379.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>marketing_posts.coupon_id -&gt; coupons.id (marketing_posts_coupon_id_fkey)</title></path>
+<path d="M 2250.0 483.0 C 2250.0 679.0, 2136.0 679.0, 2136.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>marketing_posts.merchant_id -&gt; merchants.id (marketing_posts_merchant_id_fkey)</title></path>
+<path d="M 2250.0 499.0 C 2250.0 1279.0, 2129.0 1279.0, 2129.0 2059.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>marketing_posts.store_id -&gt; stores.id (marketing_posts_store_id_fkey)</title></path>
+<path d="M 255.0 1172.0 C 255.0 1992.0, 255.0 1992.0, 255.0 2812.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>media_uploads.user_id -&gt; users.id (media_uploads_user_id_fkey)</title></path>
+<path d="M 839.0 1011.0 C 1326.0 1011.0, 1326.0 875.0, 1813.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>merchant_analytics.merchant_id -&gt; merchants.id (merchant_analytics_merchant_id_fkey)</title></path>
+<path d="M 839.0 1027.0 C 839.0 1543.0, 1820.0 1543.0, 1820.0 2059.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>merchant_analytics.store_id -&gt; stores.id (merchant_analytics_store_id_fkey)</title></path>
+<path d="M 1269.0 1083.0 C 1541.0 1083.0, 1541.0 875.0, 1813.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>merchant_follows.merchant_id -&gt; merchants.id (fk_merchant_follows_merchant)</title></path>
+<path d="M 960.0 1067.0 C 960.0 1963.0, 396.0 1963.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>merchant_follows.user_id -&gt; users.id (merchant_follows_user_id_fkey)</title></path>
+<path d="M 1813.0 891.0 C 1813.0 1875.0, 396.0 1875.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>merchants.user_id -&gt; users.id (merchants_user_id_fkey)</title></path>
+<path d="M 1699.0 1011.0 C 1699.0 943.0, 1813.0 943.0, 1813.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>merchant_verifications.merchant_id -&gt; merchants.id (merchant_verifications_merchant_id_fkey)</title></path>
+<path d="M 1390.0 1091.0 C 1390.0 1975.0, 396.0 1975.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>merchant_verifications.reviewed_by -&gt; users.id (merchant_verifications_reviewed_by_fkey)</title></path>
+<path d="M 2405.0 972.0 C 2405.0 628.0, 2405.0 628.0, 2405.0 284.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>messages.conversation_id -&gt; conversations.id (messages_conversation_id_fkey)</title></path>
+<path d="M 2223.0 1051.0 C 1309.5 1051.0, 1309.5 2859.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>messages.sender_id -&gt; users.id (messages_sender_id_fkey)</title></path>
+<path d="M 255.0 1580.0 C 255.0 2196.0, 255.0 2196.0, 255.0 2812.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>notifications.user_id -&gt; users.id (notifications_user_id_fkey)</title></path>
+<path d="M 530.0 1443.0 C 530.0 911.0, 409.0 911.0, 409.0 379.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>orders.coupon_id -&gt; coupons.id (orders_coupon_id_fkey)</title></path>
+<path d="M 839.0 1475.0 C 1326.0 1475.0, 1326.0 875.0, 1813.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>orders.merchant_id -&gt; merchants.id (orders_merchant_id_fkey)</title></path>
+<path d="M 839.0 1459.0 C 899.5 1459.0, 899.5 1371.0, 960.0 1371.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>orders.package_id -&gt; packages.id (orders_package_id_fkey)</title></path>
+<path d="M 839.0 1491.0 C 1329.5 1491.0, 1329.5 2059.0, 1820.0 2059.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>orders.store_id -&gt; stores.id (orders_store_id_fkey)</title></path>
+<path d="M 530.0 1427.0 C 530.0 2143.0, 396.0 2143.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>orders.user_id -&gt; users.id (orders_user_id_fkey)</title></path>
+<path d="M 1269.0 1387.0 C 1541.0 1387.0, 1541.0 875.0, 1813.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>packages.merchant_id -&gt; merchants.id (packages_merchant_id_fkey)</title></path>
+<path d="M 1269.0 1403.0 C 1269.0 1731.0, 1820.0 1731.0, 1820.0 2059.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>packages.store_id -&gt; stores.id (packages_store_id_fkey)</title></path>
+<path d="M 1383.0 1467.0 C 1383.0 923.0, 409.0 923.0, 409.0 379.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>payments.coupon_id -&gt; coupons.id (payments_coupon_id_fkey)</title></path>
+<path d="M 1706.0 1483.0 C 1706.0 1179.0, 1813.0 1179.0, 1813.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>payments.merchant_id -&gt; merchants.id (payments_merchant_id_fkey)</title></path>
+<path d="M 1383.0 1499.0 C 1111.0 1499.0, 1111.0 1411.0, 839.0 1411.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>payments.order_id -&gt; orders.id (payments_order_id_fkey)</title></path>
+<path d="M 1383.0 1515.0 C 1383.0 2187.0, 396.0 2187.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>payments.user_id -&gt; users.id (payments_user_id_fkey)</title></path>
+<path d="M 1974.0 1388.0 C 1974.0 1484.0, 1974.0 1484.0, 1974.0 1580.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>post_comments.parent_comment_id -&gt; post_comments.id (post_comments_parent_comment_id_fkey)</title></path>
+<path d="M 1786.0 1451.0 C 1097.5 1451.0, 1097.5 1723.0, 409.0 1723.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>post_comments.post_id -&gt; posts.id (post_comments_post_id_fkey)</title></path>
+<path d="M 1786.0 1467.0 C 1786.0 2163.0, 396.0 2163.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>post_comments.user_id -&gt; users.id (post_comments_user_id_fkey)</title></path>
+<path d="M 409.0 1755.0 C 1111.0 1755.0, 1111.0 875.0, 1813.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>posts.merchant_id -&gt; merchants.id (posts_merchant_id_fkey)</title></path>
+<path d="M 409.0 1771.0 C 409.0 1927.0, 530.0 1927.0, 530.0 2083.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>posts.review_id -&gt; reviews.id (posts_review_id_fkey)</title></path>
+<path d="M 409.0 1739.0 C 409.0 2299.0, 114.0 2299.0, 114.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>posts.user_id -&gt; users.id (posts_user_id_fkey)</title></path>
+<path d="M 2267.0 1491.0 C 1338.0 1491.0, 1338.0 1723.0, 409.0 1723.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>post_tags.post_id -&gt; posts.id (post_tags_post_id_fkey)</title></path>
+<path d="M 2542.0 1507.0 C 2542.0 1847.0, 2264.0 1847.0, 2264.0 2187.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>post_tags.tag_id -&gt; tags.id (post_tags_tag_id_fkey)</title></path>
+<path d="M 537.0 1803.0 C 537.0 2331.0, 396.0 2331.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>refresh_tokens.user_id -&gt; users.id (refresh_tokens_user_id_fkey)</title></path>
+<path d="M 970.0 1771.0 C 970.0 2315.0, 396.0 2315.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>reports.reporter_id -&gt; users.id (reports_reporter_id_fkey)</title></path>
+<path d="M 970.0 1867.0 C 970.0 2363.0, 396.0 2363.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>reports.reviewed_by -&gt; users.id (reports_reviewed_by_fkey)</title></path>
+<path d="M 1544.0 1732.0 C 1544.0 1828.0, 1544.0 1828.0, 1544.0 1924.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>review_comments.parent_comment_id -&gt; review_comments.id (review_comments_parent_comment_id_fkey)</title></path>
+<path d="M 1349.0 1795.0 C 1094.0 1795.0, 1094.0 2083.0, 839.0 2083.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>review_comments.review_id -&gt; reviews.id (review_comments_review_id_fkey)</title></path>
+<path d="M 1349.0 1811.0 C 1349.0 2335.0, 396.0 2335.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>review_comments.user_id -&gt; users.id (review_comments_user_id_fkey)</title></path>
+<path d="M 1834.0 1819.0 C 1336.5 1819.0, 1336.5 2083.0, 839.0 2083.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>review_media.review_id -&gt; reviews.id (review_media_review_id_fkey)</title></path>
+<path d="M 839.0 2131.0 C 839.0 1503.0, 1813.0 1503.0, 1813.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>reviews.merchant_id -&gt; merchants.id (reviews_merchant_id_fkey)</title></path>
+<path d="M 839.0 2147.0 C 1329.5 2147.0, 1329.5 2059.0, 1820.0 2059.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>reviews.store_id -&gt; stores.id (reviews_store_id_fkey)</title></path>
+<path d="M 530.0 2099.0 C 530.0 2479.0, 396.0 2479.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>reviews.user_id -&gt; users.id (reviews_user_id_fkey)</title></path>
+<path d="M 2254.0 1835.0 C 1546.5 1835.0, 1546.5 2083.0, 839.0 2083.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>review_tags.review_id -&gt; reviews.id (review_tags_review_id_fkey)</title></path>
+<path d="M 2405.0 1868.0 C 2405.0 2004.0, 2405.0 2004.0, 2405.0 2140.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>review_tags.tag_id -&gt; tags.id (review_tags_tag_id_fkey)</title></path>
+<path d="M 396.0 2211.0 C 463.0 2211.0, 463.0 2083.0, 530.0 2083.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>review_votes.review_id -&gt; reviews.id (review_votes_review_id_fkey)</title></path>
+<path d="M 255.0 2276.0 C 255.0 2544.0, 255.0 2544.0, 255.0 2812.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>review_votes.user_id -&gt; users.id (review_votes_user_id_fkey)</title></path>
+<path d="M 1283.0 2235.0 C 1283.0 1223.0, 1394.0 1223.0, 1394.0 211.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>store_categories.category_id -&gt; categories.id (store_categories_category_id_fkey)</title></path>
+<path d="M 1283.0 2219.0 C 1551.5 2219.0, 1551.5 2059.0, 1820.0 2059.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>store_categories.store_id -&gt; stores.id (store_categories_store_id_fkey)</title></path>
+<path d="M 1679.0 2203.0 C 1679.0 2131.0, 1820.0 2131.0, 1820.0 2059.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>store_hours.store_id -&gt; stores.id (store_hours_store_id_fkey)</title></path>
+<path d="M 1974.0 2012.0 C 1974.0 1652.0, 1974.0 1652.0, 1974.0 1292.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>stores.merchant_id -&gt; merchants.id (stores_merchant_id_fkey)</title></path>
+<path d="M 255.0 2684.0 C 255.0 2748.0, 255.0 2748.0, 255.0 2812.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>user_addresses.user_id -&gt; users.id (user_addresses_user_id_fkey)</title></path>
+<path d="M 523.0 2555.0 C 523.0 2707.0, 396.0 2707.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>user_auths.user_id -&gt; users.id (fk_users_auths)</title></path>
+<path d="M 523.0 2555.0 C 523.0 2707.0, 396.0 2707.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>user_auths.user_id -&gt; users.id (user_auths_user_id_fkey)</title></path>
+<path d="M 970.0 2571.0 C 683.0 2571.0, 683.0 2859.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>user_follows.follower_id -&gt; users.id (user_follows_follower_id_fkey)</title></path>
+<path d="M 970.0 2587.0 C 683.0 2587.0, 683.0 2859.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>user_follows.following_id -&gt; users.id (user_follows_following_id_fkey)</title></path>
+<path d="M 1407.0 2563.0 C 901.5 2563.0, 901.5 2859.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>user_notifications.user_id -&gt; users.id (user_notifications_user_id_fkey)</title></path>
+<path d="M 1837.0 2571.0 C 1116.5 2571.0, 1116.5 2859.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>user_privacies.user_id -&gt; users.id (user_privacies_user_id_fkey)</title></path>
+<path d="M 2233.0 2499.0 C 1314.5 2499.0, 1314.5 2859.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>user_profiles.user_id -&gt; users.id (fk_users_profile)</title></path>
+<path d="M 2233.0 2499.0 C 1314.5 2499.0, 1314.5 2859.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>user_profiles.user_id -&gt; users.id (user_profiles_user_id_fkey)</title></path>
+<path d="M 530.0 2795.0 C 530.0 1587.0, 409.0 1587.0, 409.0 379.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>vouchers.coupon_id -&gt; coupons.id (vouchers_coupon_id_fkey)</title></path>
+<path d="M 839.0 2859.0 C 839.0 1867.0, 1813.0 1867.0, 1813.0 875.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>vouchers.merchant_id -&gt; merchants.id (vouchers_merchant_id_fkey)</title></path>
+<path d="M 684.0 2716.0 C 684.0 2160.0, 684.0 2160.0, 684.0 1604.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>vouchers.order_id -&gt; orders.id (vouchers_order_id_fkey)</title></path>
+<path d="M 839.0 2827.0 C 839.0 2099.0, 960.0 2099.0, 960.0 1371.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>vouchers.package_id -&gt; packages.id (vouchers_package_id_fkey)</title></path>
+<path d="M 530.0 2955.0 C 463.0 2955.0, 463.0 2859.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>vouchers.redeemed_by -&gt; users.id (vouchers_redeemed_by_fkey)</title></path>
+<path d="M 530.0 2811.0 C 463.0 2811.0, 463.0 2859.0, 396.0 2859.0" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" fill="none" marker-end="url(#arrow)"><title>vouchers.user_id -&gt; users.id (vouchers_user_id_fkey)</title></path>
+<rect x="107" y="156" width="296" height="128" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="107" y="156" width="296" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="117" y="176" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">account_deletions</text>
+<line x1="107" y1="188" x2="403" y2="188" stroke="#94a3b8" stroke-width="1" />
+<text x="117" y="210" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="117" y="226" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="117" y="242" font-family="Courier New, monospace" font-size="11" fill="#0f172a">reason: character varying(255) ?</text>
+<text x="117" y="258" font-family="Courier New, monospace" font-size="11" fill="#0f172a">scheduled_at: timestamp with time zone ?</text>
+<text x="117" y="274" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="544" y="140" width="282" height="160" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="544" y="140" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="554" y="160" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">admin_audit_logs</text>
+<line x1="544" y1="172" x2="826" y2="172" stroke="#94a3b8" stroke-width="1" />
+<text x="554" y="194" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="554" y="210" font-family="Courier New, monospace" font-size="11" fill="#0f172a">admin_id: bigint ? [FK] -&gt; users.id</text>
+<text x="554" y="226" font-family="Courier New, monospace" font-size="11" fill="#0f172a">action: character varying(50) ?</text>
+<text x="554" y="242" font-family="Courier New, monospace" font-size="11" fill="#0f172a">target_type: character varying(20) ?</text>
+<text x="554" y="258" font-family="Courier New, monospace" font-size="11" fill="#0f172a">target_id: bigint ?</text>
+<text x="554" y="274" font-family="Courier New, monospace" font-size="11" fill="#0f172a">details: jsonb ?</text>
+<text x="554" y="290" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="974" y="140" width="282" height="160" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="974" y="140" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="984" y="160" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">browsing_histories</text>
+<line x1="974" y1="172" x2="1256" y2="172" stroke="#94a3b8" stroke-width="1" />
+<text x="984" y="194" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="984" y="210" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="984" y="226" font-family="Courier New, monospace" font-size="11" fill="#0f172a">store_id: bigint ? [FK] -&gt; stores.id</text>
+<text x="984" y="242" font-family="Courier New, monospace" font-size="11" fill="#0f172a">review_id: bigint ? [FK] -&gt; reviews.id</text>
+<text x="984" y="258" font-family="Courier New, monospace" font-size="11" fill="#0f172a">post_id: bigint ? [FK] -&gt; posts.id</text>
+<text x="984" y="274" font-family="Courier New, monospace" font-size="11" fill="#0f172a">viewed_at: timestamp with time zone ?</text>
+<text x="984" y="290" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="1394" y="164" width="302" height="112" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1394" y="164" width="302" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1404" y="184" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">categories</text>
+<line x1="1394" y1="196" x2="1696" y2="196" stroke="#94a3b8" stroke-width="1" />
+<text x="1404" y="218" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1404" y="234" font-family="Courier New, monospace" font-size="11" fill="#0f172a">name: character varying(50) ?</text>
+<text x="1404" y="250" font-family="Courier New, monospace" font-size="11" fill="#0f172a">parent_id: bigint ? [FK] -&gt; categories.id</text>
+<text x="1404" y="266" font-family="Courier New, monospace" font-size="11" fill="#0f172a">icon_url: character varying(255) ?</text>
+<rect x="1793" y="140" width="364" height="160" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1793" y="140" width="364" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1803" y="160" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">conversation_participants</text>
+<line x1="1793" y1="172" x2="2157" y2="172" stroke="#94a3b8" stroke-width="1" />
+<text x="1803" y="194" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1803" y="210" font-family="Courier New, monospace" font-size="11" fill="#0f172a">conversation_id: bigint ? [FK] -&gt; conversations.id</text>
+<text x="1803" y="226" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="1803" y="242" font-family="Courier New, monospace" font-size="11" fill="#0f172a">role: character varying(20) ?</text>
+<text x="1803" y="258" font-family="Courier New, monospace" font-size="11" fill="#0f172a">is_muted: boolean ?</text>
+<text x="1803" y="274" font-family="Courier New, monospace" font-size="11" fill="#0f172a">last_read_at: timestamp with time zone ?</text>
+<text x="1803" y="290" font-family="Courier New, monospace" font-size="11" fill="#0f172a">joined_at: timestamp with time zone ?</text>
+<rect x="2264" y="156" width="282" height="128" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="2264" y="156" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="2274" y="176" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">conversations</text>
+<line x1="2264" y1="188" x2="2546" y2="188" stroke="#94a3b8" stroke-width="1" />
+<text x="2274" y="210" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="2274" y="226" font-family="Courier New, monospace" font-size="11" fill="#0f172a">type: character varying(20) ?</text>
+<text x="2274" y="242" font-family="Courier New, monospace" font-size="11" fill="#0f172a">title: character varying(100) ?</text>
+<text x="2274" y="258" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="2274" y="274" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="100" y="332" width="309" height="464" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="100" y="332" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="110" y="352" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">coupons</text>
+<line x1="100" y1="364" x2="409" y2="364" stroke="#94a3b8" stroke-width="1" />
+<text x="110" y="386" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="110" y="402" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="110" y="418" font-family="Courier New, monospace" font-size="11" fill="#0f172a">store_id: bigint ? [FK] -&gt; stores.id</text>
+<text x="110" y="434" font-family="Courier New, monospace" font-size="11" fill="#0f172a">package_id: bigint ? [FK] -&gt; packages.id</text>
+<text x="110" y="450" font-family="Courier New, monospace" font-size="11" fill="#0f172a">title: character varying(100) ?</text>
+<text x="110" y="466" font-family="Courier New, monospace" font-size="11" fill="#0f172a">description: text ?</text>
+<text x="110" y="482" font-family="Courier New, monospace" font-size="11" fill="#0f172a">image_url: character varying(255) ?</text>
+<text x="110" y="498" font-family="Courier New, monospace" font-size="11" fill="#0f172a">type: character varying(20) ?</text>
+<text x="110" y="514" font-family="Courier New, monospace" font-size="11" fill="#0f172a">coupon_type: character varying(20) ?</text>
+<text x="110" y="530" font-family="Courier New, monospace" font-size="11" fill="#0f172a">value: character varying(50) ?</text>
+<text x="110" y="546" font-family="Courier New, monospace" font-size="11" fill="#0f172a">price: numeric(10,2) ?</text>
+<text x="110" y="562" font-family="Courier New, monospace" font-size="11" fill="#0f172a">original_price: numeric(10,2) ?</text>
+<text x="110" y="578" font-family="Courier New, monospace" font-size="11" fill="#0f172a">sale_price: numeric(10,2) ?</text>
+<text x="110" y="594" font-family="Courier New, monospace" font-size="11" fill="#0f172a">discount_percentage: numeric(5,2) ?</text>
+<text x="110" y="610" font-family="Courier New, monospace" font-size="11" fill="#0f172a">total_quantity: integer ?</text>
+<text x="110" y="626" font-family="Courier New, monospace" font-size="11" fill="#0f172a">claimed_count: integer ?</text>
+<text x="110" y="642" font-family="Courier New, monospace" font-size="11" fill="#0f172a">redeemed_count: integer ?</text>
+<text x="110" y="658" font-family="Courier New, monospace" font-size="11" fill="#0f172a">max_per_user: integer ?</text>
+<text x="110" y="674" font-family="Courier New, monospace" font-size="11" fill="#0f172a">terms: text ?</text>
+<text x="110" y="690" font-family="Courier New, monospace" font-size="11" fill="#0f172a">expiry_date: timestamp with time zone ?</text>
+<text x="110" y="706" font-family="Courier New, monospace" font-size="11" fill="#0f172a">valid_from: timestamp with time zone ?</text>
+<text x="110" y="722" font-family="Courier New, monospace" font-size="11" fill="#0f172a">valid_until: timestamp with time zone ?</text>
+<text x="110" y="738" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: character varying(20) ?</text>
+<text x="110" y="754" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="110" y="770" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<text x="110" y="786" font-family="Courier New, monospace" font-size="11" fill="#0f172a">deleted_at: timestamp with time zone ?</text>
+<rect x="544" y="492" width="282" height="144" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="544" y="492" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="554" y="512" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">email_verifications</text>
+<line x1="544" y1="524" x2="826" y2="524" stroke="#94a3b8" stroke-width="1" />
+<text x="554" y="546" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="554" y="562" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="554" y="578" font-family="Courier New, monospace" font-size="11" fill="#0f172a">email: character varying(255) ?</text>
+<text x="554" y="594" font-family="Courier New, monospace" font-size="11" fill="#0f172a">token: character varying(255) ?</text>
+<text x="554" y="610" font-family="Courier New, monospace" font-size="11" fill="#0f172a">expires_at: timestamp with time zone ?</text>
+<text x="554" y="626" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="974" y="500" width="282" height="128" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="974" y="500" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="984" y="520" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">favorites</text>
+<line x1="974" y1="532" x2="1256" y2="532" stroke="#94a3b8" stroke-width="1" />
+<text x="984" y="554" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="984" y="570" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ?</text>
+<text x="984" y="586" font-family="Courier New, monospace" font-size="11" fill="#0f172a">target_type: character varying(20) ?</text>
+<text x="984" y="602" font-family="Courier New, monospace" font-size="11" fill="#0f172a">target_id: bigint ?</text>
+<text x="984" y="618" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="1407" y="508" width="275" height="112" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1407" y="508" width="275" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1417" y="528" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">goose_db_version</text>
+<line x1="1407" y1="540" x2="1682" y2="540" stroke="#94a3b8" stroke-width="1" />
+<text x="1417" y="562" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: integer ? [PK]</text>
+<text x="1417" y="578" font-family="Courier New, monospace" font-size="11" fill="#0f172a">version_id: bigint ?</text>
+<text x="1417" y="594" font-family="Courier New, monospace" font-size="11" fill="#0f172a">is_applied: boolean ?</text>
+<text x="1417" y="610" font-family="Courier New, monospace" font-size="11" fill="#0f172a">tstamp: timestamp without time zone ?</text>
+<rect x="1834" y="500" width="282" height="128" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1834" y="500" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1844" y="520" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">likes</text>
+<line x1="1834" y1="532" x2="2116" y2="532" stroke="#94a3b8" stroke-width="1" />
+<text x="1844" y="554" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1844" y="570" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ?</text>
+<text x="1844" y="586" font-family="Courier New, monospace" font-size="11" fill="#0f172a">target_type: character varying(20) ?</text>
+<text x="1844" y="602" font-family="Courier New, monospace" font-size="11" fill="#0f172a">target_id: bigint ?</text>
+<text x="1844" y="618" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="2250" y="420" width="309" height="288" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="2250" y="420" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="2260" y="440" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">marketing_posts</text>
+<line x1="2250" y1="452" x2="2559" y2="452" stroke="#94a3b8" stroke-width="1" />
+<text x="2260" y="474" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="2260" y="490" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="2260" y="506" font-family="Courier New, monospace" font-size="11" fill="#0f172a">store_id: bigint ? [FK] -&gt; stores.id</text>
+<text x="2260" y="522" font-family="Courier New, monospace" font-size="11" fill="#0f172a">title: character varying(100) ?</text>
+<text x="2260" y="538" font-family="Courier New, monospace" font-size="11" fill="#0f172a">content: text ?</text>
+<text x="2260" y="554" font-family="Courier New, monospace" font-size="11" fill="#0f172a">images: jsonb ?</text>
+<text x="2260" y="570" font-family="Courier New, monospace" font-size="11" fill="#0f172a">post_type: character varying(20) ?</text>
+<text x="2260" y="586" font-family="Courier New, monospace" font-size="11" fill="#0f172a">coupon_id: bigint ? [FK] -&gt; coupons.id</text>
+<text x="2260" y="602" font-family="Courier New, monospace" font-size="11" fill="#0f172a">start_date: timestamp with time zone ?</text>
+<text x="2260" y="618" font-family="Courier New, monospace" font-size="11" fill="#0f172a">end_date: timestamp with time zone ?</text>
+<text x="2260" y="634" font-family="Courier New, monospace" font-size="11" fill="#0f172a">view_count: integer ?</text>
+<text x="2260" y="650" font-family="Courier New, monospace" font-size="11" fill="#0f172a">click_count: integer ?</text>
+<text x="2260" y="666" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: character varying(20) ?</text>
+<text x="2260" y="682" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="2260" y="698" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="114" y="948" width="282" height="224" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="114" y="948" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="124" y="968" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">media_uploads</text>
+<line x1="114" y1="980" x2="396" y2="980" stroke="#94a3b8" stroke-width="1" />
+<text x="124" y="1002" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="124" y="1018" font-family="Courier New, monospace" font-size="11" fill="#0f172a">uuid: character varying(36) ?</text>
+<text x="124" y="1034" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="124" y="1050" font-family="Courier New, monospace" font-size="11" fill="#0f172a">object_key: character varying(512) ?</text>
+<text x="124" y="1066" font-family="Courier New, monospace" font-size="11" fill="#0f172a">file_url: character varying(512) ?</text>
+<text x="124" y="1082" font-family="Courier New, monospace" font-size="11" fill="#0f172a">file_size: bigint ?</text>
+<text x="124" y="1098" font-family="Courier New, monospace" font-size="11" fill="#0f172a">mime_type: character varying(100) ?</text>
+<text x="124" y="1114" font-family="Courier New, monospace" font-size="11" fill="#0f172a">r2_bucket: character varying(100) ?</text>
+<text x="124" y="1130" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: character varying(20) ?</text>
+<text x="124" y="1146" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="124" y="1162" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="530" y="948" width="309" height="224" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="530" y="948" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="540" y="968" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">merchant_analytics</text>
+<line x1="530" y1="980" x2="839" y2="980" stroke="#94a3b8" stroke-width="1" />
+<text x="540" y="1002" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="540" y="1018" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="540" y="1034" font-family="Courier New, monospace" font-size="11" fill="#0f172a">store_id: bigint ? [FK] -&gt; stores.id</text>
+<text x="540" y="1050" font-family="Courier New, monospace" font-size="11" fill="#0f172a">date: date ?</text>
+<text x="540" y="1066" font-family="Courier New, monospace" font-size="11" fill="#0f172a">total_views: integer ?</text>
+<text x="540" y="1082" font-family="Courier New, monospace" font-size="11" fill="#0f172a">unique_visitors: integer ?</text>
+<text x="540" y="1098" font-family="Courier New, monospace" font-size="11" fill="#0f172a">reviews_received: integer ?</text>
+<text x="540" y="1114" font-family="Courier New, monospace" font-size="11" fill="#0f172a">coupons_redeemed: integer ?</text>
+<text x="540" y="1130" font-family="Courier New, monospace" font-size="11" fill="#0f172a">revenue: numeric(12,2) ?</text>
+<text x="540" y="1146" font-family="Courier New, monospace" font-size="11" fill="#0f172a">avg_rating: numeric(3,2) ?</text>
+<text x="540" y="1162" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="960" y="1004" width="309" height="112" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="960" y="1004" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="970" y="1024" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">merchant_follows</text>
+<line x1="960" y1="1036" x2="1269" y2="1036" stroke="#94a3b8" stroke-width="1" />
+<text x="970" y="1058" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="970" y="1074" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="970" y="1090" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="970" y="1106" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="1390" y="948" width="309" height="224" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1390" y="948" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1400" y="968" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">merchant_verifications</text>
+<line x1="1390" y1="980" x2="1699" y2="980" stroke="#94a3b8" stroke-width="1" />
+<text x="1400" y="1002" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1400" y="1018" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="1400" y="1034" font-family="Courier New, monospace" font-size="11" fill="#0f172a">document_type: character varying(50) ?</text>
+<text x="1400" y="1050" font-family="Courier New, monospace" font-size="11" fill="#0f172a">document_url: character varying(512) ?</text>
+<text x="1400" y="1066" font-family="Courier New, monospace" font-size="11" fill="#0f172a">business_license: character varying(255) ?</text>
+<text x="1400" y="1082" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: character varying(20) ?</text>
+<text x="1400" y="1098" font-family="Courier New, monospace" font-size="11" fill="#0f172a">reviewed_by: bigint ? [FK] -&gt; users.id</text>
+<text x="1400" y="1114" font-family="Courier New, monospace" font-size="11" fill="#0f172a">reviewed_at: timestamp with time zone ?</text>
+<text x="1400" y="1130" font-family="Courier New, monospace" font-size="11" fill="#0f172a">rejection_reason: text ?</text>
+<text x="1400" y="1146" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="1400" y="1162" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="1813" y="828" width="323" height="464" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1813" y="828" width="323" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1823" y="848" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">merchants</text>
+<line x1="1813" y1="860" x2="2136" y2="860" stroke="#94a3b8" stroke-width="1" />
+<text x="1823" y="882" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1823" y="898" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="1823" y="914" font-family="Courier New, monospace" font-size="11" fill="#0f172a">name: character varying(100) ?</text>
+<text x="1823" y="930" font-family="Courier New, monospace" font-size="11" fill="#0f172a">business_name: character varying(100) ?</text>
+<text x="1823" y="946" font-family="Courier New, monospace" font-size="11" fill="#0f172a">business_type: character varying(50) ?</text>
+<text x="1823" y="962" font-family="Courier New, monospace" font-size="11" fill="#0f172a">category: character varying(50) ?</text>
+<text x="1823" y="978" font-family="Courier New, monospace" font-size="11" fill="#0f172a">logo_url: character varying(255) ?</text>
+<text x="1823" y="994" font-family="Courier New, monospace" font-size="11" fill="#0f172a">address: character varying(255) ?</text>
+<text x="1823" y="1010" font-family="Courier New, monospace" font-size="11" fill="#0f172a">phone: character varying(20) ?</text>
+<text x="1823" y="1026" font-family="Courier New, monospace" font-size="11" fill="#0f172a">contact_phone: character varying(20) ?</text>
+<text x="1823" y="1042" font-family="Courier New, monospace" font-size="11" fill="#0f172a">contact_email: character varying(255) ?</text>
+<text x="1823" y="1058" font-family="Courier New, monospace" font-size="11" fill="#0f172a">website_url: character varying(255) ?</text>
+<text x="1823" y="1074" font-family="Courier New, monospace" font-size="11" fill="#0f172a">social_links: jsonb ?</text>
+<text x="1823" y="1090" font-family="Courier New, monospace" font-size="11" fill="#0f172a">cover_image: character varying(255) ?</text>
+<text x="1823" y="1106" font-family="Courier New, monospace" font-size="11" fill="#0f172a">description: text ?</text>
+<text x="1823" y="1122" font-family="Courier New, monospace" font-size="11" fill="#0f172a">avg_rating: numeric(3,2) ?</text>
+<text x="1823" y="1138" font-family="Courier New, monospace" font-size="11" fill="#0f172a">review_count: integer ?</text>
+<text x="1823" y="1154" font-family="Courier New, monospace" font-size="11" fill="#0f172a">follower_count: integer ?</text>
+<text x="1823" y="1170" font-family="Courier New, monospace" font-size="11" fill="#0f172a">total_stores: integer ?</text>
+<text x="1823" y="1186" font-family="Courier New, monospace" font-size="11" fill="#0f172a">total_reviews: integer ?</text>
+<text x="1823" y="1202" font-family="Courier New, monospace" font-size="11" fill="#0f172a">verification_status: character varying(20) ?</text>
+<text x="1823" y="1218" font-family="Courier New, monospace" font-size="11" fill="#0f172a">verified_at: timestamp with time zone ?</text>
+<text x="1823" y="1234" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: smallint ?</text>
+<text x="1823" y="1250" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="1823" y="1266" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<text x="1823" y="1282" font-family="Courier New, monospace" font-size="11" fill="#0f172a">deleted_at: timestamp with time zone ?</text>
+<rect x="2223" y="972" width="364" height="176" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="2223" y="972" width="364" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="2233" y="992" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">messages</text>
+<line x1="2223" y1="1004" x2="2587" y2="1004" stroke="#94a3b8" stroke-width="1" />
+<text x="2233" y="1026" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="2233" y="1042" font-family="Courier New, monospace" font-size="11" fill="#0f172a">conversation_id: bigint ? [FK] -&gt; conversations.id</text>
+<text x="2233" y="1058" font-family="Courier New, monospace" font-size="11" fill="#0f172a">sender_id: bigint ? [FK] -&gt; users.id</text>
+<text x="2233" y="1074" font-family="Courier New, monospace" font-size="11" fill="#0f172a">content: text ?</text>
+<text x="2233" y="1090" font-family="Courier New, monospace" font-size="11" fill="#0f172a">message_type: character varying(20) ?</text>
+<text x="2233" y="1106" font-family="Courier New, monospace" font-size="11" fill="#0f172a">attachments: jsonb ?</text>
+<text x="2233" y="1122" font-family="Courier New, monospace" font-size="11" fill="#0f172a">is_read: boolean ?</text>
+<text x="2233" y="1138" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="114" y="1388" width="282" height="192" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="114" y="1388" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="124" y="1408" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">notifications</text>
+<line x1="114" y1="1420" x2="396" y2="1420" stroke="#94a3b8" stroke-width="1" />
+<text x="124" y="1442" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="124" y="1458" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="124" y="1474" font-family="Courier New, monospace" font-size="11" fill="#0f172a">type: character varying(50) ?</text>
+<text x="124" y="1490" font-family="Courier New, monospace" font-size="11" fill="#0f172a">title: character varying(255) ?</text>
+<text x="124" y="1506" font-family="Courier New, monospace" font-size="11" fill="#0f172a">content: text ?</text>
+<text x="124" y="1522" font-family="Courier New, monospace" font-size="11" fill="#0f172a">data: jsonb ?</text>
+<text x="124" y="1538" font-family="Courier New, monospace" font-size="11" fill="#0f172a">is_read: boolean ?</text>
+<text x="124" y="1554" font-family="Courier New, monospace" font-size="11" fill="#0f172a">read_at: timestamp with time zone ?</text>
+<text x="124" y="1570" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="530" y="1364" width="309" height="240" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="530" y="1364" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="540" y="1384" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">orders</text>
+<line x1="530" y1="1396" x2="839" y2="1396" stroke="#94a3b8" stroke-width="1" />
+<text x="540" y="1418" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="540" y="1434" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="540" y="1450" font-family="Courier New, monospace" font-size="11" fill="#0f172a">coupon_id: bigint ? [FK] -&gt; coupons.id</text>
+<text x="540" y="1466" font-family="Courier New, monospace" font-size="11" fill="#0f172a">package_id: bigint ? [FK] -&gt; packages.id</text>
+<text x="540" y="1482" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="540" y="1498" font-family="Courier New, monospace" font-size="11" fill="#0f172a">store_id: bigint ? [FK] -&gt; stores.id</text>
+<text x="540" y="1514" font-family="Courier New, monospace" font-size="11" fill="#0f172a">quantity: integer ?</text>
+<text x="540" y="1530" font-family="Courier New, monospace" font-size="11" fill="#0f172a">total_price: numeric(10,2) ?</text>
+<text x="540" y="1546" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: character varying(20) ?</text>
+<text x="540" y="1562" font-family="Courier New, monospace" font-size="11" fill="#0f172a">note: text ?</text>
+<text x="540" y="1578" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="540" y="1594" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="960" y="1324" width="309" height="320" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="960" y="1324" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="970" y="1344" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">packages</text>
+<line x1="960" y1="1356" x2="1269" y2="1356" stroke="#94a3b8" stroke-width="1" />
+<text x="970" y="1378" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="970" y="1394" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="970" y="1410" font-family="Courier New, monospace" font-size="11" fill="#0f172a">store_id: bigint ? [FK] -&gt; stores.id</text>
+<text x="970" y="1426" font-family="Courier New, monospace" font-size="11" fill="#0f172a">title: character varying(100) ?</text>
+<text x="970" y="1442" font-family="Courier New, monospace" font-size="11" fill="#0f172a">description: text ?</text>
+<text x="970" y="1458" font-family="Courier New, monospace" font-size="11" fill="#0f172a">image_url: character varying(255) ?</text>
+<text x="970" y="1474" font-family="Courier New, monospace" font-size="11" fill="#0f172a">original_price: numeric(10,2) ?</text>
+<text x="970" y="1490" font-family="Courier New, monospace" font-size="11" fill="#0f172a">sale_price: numeric(10,2) ?</text>
+<text x="970" y="1506" font-family="Courier New, monospace" font-size="11" fill="#0f172a">discount_percentage: numeric(5,2) ?</text>
+<text x="970" y="1522" font-family="Courier New, monospace" font-size="11" fill="#0f172a">total_quantity: integer ?</text>
+<text x="970" y="1538" font-family="Courier New, monospace" font-size="11" fill="#0f172a">sold_count: integer ?</text>
+<text x="970" y="1554" font-family="Courier New, monospace" font-size="11" fill="#0f172a">valid_from: timestamp with time zone ?</text>
+<text x="970" y="1570" font-family="Courier New, monospace" font-size="11" fill="#0f172a">valid_until: timestamp with time zone ?</text>
+<text x="970" y="1586" font-family="Courier New, monospace" font-size="11" fill="#0f172a">terms: text ?</text>
+<text x="970" y="1602" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: character varying(20) ?</text>
+<text x="970" y="1618" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="970" y="1634" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="1383" y="1356" width="323" height="256" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1383" y="1356" width="323" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1393" y="1376" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">payments</text>
+<line x1="1383" y1="1388" x2="1706" y2="1388" stroke="#94a3b8" stroke-width="1" />
+<text x="1393" y="1410" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1393" y="1426" font-family="Courier New, monospace" font-size="11" fill="#0f172a">amount: numeric(10,2) ?</text>
+<text x="1393" y="1442" font-family="Courier New, monospace" font-size="11" fill="#0f172a">currency: character varying(10) ?</text>
+<text x="1393" y="1458" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: character varying(20) ?</text>
+<text x="1393" y="1474" font-family="Courier New, monospace" font-size="11" fill="#0f172a">coupon_id: bigint ? [FK] -&gt; coupons.id</text>
+<text x="1393" y="1490" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="1393" y="1506" font-family="Courier New, monospace" font-size="11" fill="#0f172a">order_id: bigint ? [FK] -&gt; orders.id</text>
+<text x="1393" y="1522" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="1393" y="1538" font-family="Courier New, monospace" font-size="11" fill="#0f172a">payment_method: character varying(30) ?</text>
+<text x="1393" y="1554" font-family="Courier New, monospace" font-size="11" fill="#0f172a">payment_session_id: character varying(255) ?</text>
+<text x="1393" y="1570" font-family="Courier New, monospace" font-size="11" fill="#0f172a">paid_at: timestamp with time zone ?</text>
+<text x="1393" y="1586" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="1393" y="1602" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="1786" y="1388" width="377" height="192" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1786" y="1388" width="377" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1796" y="1408" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">post_comments</text>
+<line x1="1786" y1="1420" x2="2163" y2="1420" stroke="#94a3b8" stroke-width="1" />
+<text x="1796" y="1442" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1796" y="1458" font-family="Courier New, monospace" font-size="11" fill="#0f172a">post_id: bigint ? [FK] -&gt; posts.id</text>
+<text x="1796" y="1474" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="1796" y="1490" font-family="Courier New, monospace" font-size="11" fill="#0f172a">parent_comment_id: bigint ? [FK] -&gt; post_comments.id</text>
+<text x="1796" y="1506" font-family="Courier New, monospace" font-size="11" fill="#0f172a">content: text ?</text>
+<text x="1796" y="1522" font-family="Courier New, monospace" font-size="11" fill="#0f172a">like_count: integer ?</text>
+<text x="1796" y="1538" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: smallint ?</text>
+<text x="1796" y="1554" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="1796" y="1570" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="2267" y="1444" width="275" height="80" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="2267" y="1444" width="275" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="2277" y="1464" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">post_tags</text>
+<line x1="2267" y1="1476" x2="2542" y2="1476" stroke="#94a3b8" stroke-width="1" />
+<text x="2277" y="1498" font-family="Courier New, monospace" font-size="11" fill="#0f172a">post_id: bigint ? [PK,FK] -&gt; posts.id</text>
+<text x="2277" y="1514" font-family="Courier New, monospace" font-size="11" fill="#0f172a">tag_id: bigint ? [PK,FK] -&gt; tags.id</text>
+<rect x="100" y="1676" width="309" height="304" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="100" y="1676" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="110" y="1696" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">posts</text>
+<line x1="100" y1="1708" x2="409" y2="1708" stroke="#94a3b8" stroke-width="1" />
+<text x="110" y="1730" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="110" y="1746" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="110" y="1762" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="110" y="1778" font-family="Courier New, monospace" font-size="11" fill="#0f172a">review_id: bigint ? [FK] -&gt; reviews.id</text>
+<text x="110" y="1794" font-family="Courier New, monospace" font-size="11" fill="#0f172a">post_type: character varying(20) ?</text>
+<text x="110" y="1810" font-family="Courier New, monospace" font-size="11" fill="#0f172a">title: character varying(100) ?</text>
+<text x="110" y="1826" font-family="Courier New, monospace" font-size="11" fill="#0f172a">content: text ?</text>
+<text x="110" y="1842" font-family="Courier New, monospace" font-size="11" fill="#0f172a">images: jsonb ?</text>
+<text x="110" y="1858" font-family="Courier New, monospace" font-size="11" fill="#0f172a">like_count: integer ?</text>
+<text x="110" y="1874" font-family="Courier New, monospace" font-size="11" fill="#0f172a">comment_count: integer ?</text>
+<text x="110" y="1890" font-family="Courier New, monospace" font-size="11" fill="#0f172a">share_count: integer ?</text>
+<text x="110" y="1906" font-family="Courier New, monospace" font-size="11" fill="#0f172a">view_count: integer ?</text>
+<text x="110" y="1922" font-family="Courier New, monospace" font-size="11" fill="#0f172a">is_pinned: boolean ?</text>
+<text x="110" y="1938" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: smallint ?</text>
+<text x="110" y="1954" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="110" y="1970" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="537" y="1740" width="296" height="176" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="537" y="1740" width="296" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="547" y="1760" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">refresh_tokens</text>
+<line x1="537" y1="1772" x2="833" y2="1772" stroke="#94a3b8" stroke-width="1" />
+<text x="547" y="1794" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="547" y="1810" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="547" y="1826" font-family="Courier New, monospace" font-size="11" fill="#0f172a">token_hash: character(64) ?</text>
+<text x="547" y="1842" font-family="Courier New, monospace" font-size="11" fill="#0f172a">expires_at: timestamp with time zone ?</text>
+<text x="547" y="1858" font-family="Courier New, monospace" font-size="11" fill="#0f172a">revoked_at: timestamp with time zone ?</text>
+<text x="547" y="1874" font-family="Courier New, monospace" font-size="11" fill="#0f172a">last_used_at: timestamp with time zone ?</text>
+<text x="547" y="1890" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="547" y="1906" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="970" y="1708" width="289" height="240" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="970" y="1708" width="289" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="980" y="1728" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">reports</text>
+<line x1="970" y1="1740" x2="1259" y2="1740" stroke="#94a3b8" stroke-width="1" />
+<text x="980" y="1762" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="980" y="1778" font-family="Courier New, monospace" font-size="11" fill="#0f172a">reporter_id: bigint ? [FK] -&gt; users.id</text>
+<text x="980" y="1794" font-family="Courier New, monospace" font-size="11" fill="#0f172a">target_type: character varying(20) ?</text>
+<text x="980" y="1810" font-family="Courier New, monospace" font-size="11" fill="#0f172a">target_id: bigint ?</text>
+<text x="980" y="1826" font-family="Courier New, monospace" font-size="11" fill="#0f172a">reason: character varying(50) ?</text>
+<text x="980" y="1842" font-family="Courier New, monospace" font-size="11" fill="#0f172a">description: text ?</text>
+<text x="980" y="1858" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: character varying(20) ?</text>
+<text x="980" y="1874" font-family="Courier New, monospace" font-size="11" fill="#0f172a">reviewed_by: bigint ? [FK] -&gt; users.id</text>
+<text x="980" y="1890" font-family="Courier New, monospace" font-size="11" fill="#0f172a">reviewed_at: timestamp with time zone ?</text>
+<text x="980" y="1906" font-family="Courier New, monospace" font-size="11" fill="#0f172a">resolution: text ?</text>
+<text x="980" y="1922" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="980" y="1938" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="1349" y="1732" width="391" height="192" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1349" y="1732" width="391" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1359" y="1752" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">review_comments</text>
+<line x1="1349" y1="1764" x2="1740" y2="1764" stroke="#94a3b8" stroke-width="1" />
+<text x="1359" y="1786" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1359" y="1802" font-family="Courier New, monospace" font-size="11" fill="#0f172a">review_id: bigint ? [FK] -&gt; reviews.id</text>
+<text x="1359" y="1818" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="1359" y="1834" font-family="Courier New, monospace" font-size="11" fill="#0f172a">parent_comment_id: bigint ? [FK] -&gt; review_comments.id</text>
+<text x="1359" y="1850" font-family="Courier New, monospace" font-size="11" fill="#0f172a">content: text ?</text>
+<text x="1359" y="1866" font-family="Courier New, monospace" font-size="11" fill="#0f172a">is_merchant_reply: boolean ?</text>
+<text x="1359" y="1882" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: smallint ?</text>
+<text x="1359" y="1898" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="1359" y="1914" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="1834" y="1756" width="282" height="144" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1834" y="1756" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1844" y="1776" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">review_media</text>
+<line x1="1834" y1="1788" x2="2116" y2="1788" stroke="#94a3b8" stroke-width="1" />
+<text x="1844" y="1810" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1844" y="1826" font-family="Courier New, monospace" font-size="11" fill="#0f172a">review_id: bigint ? [FK] -&gt; reviews.id</text>
+<text x="1844" y="1842" font-family="Courier New, monospace" font-size="11" fill="#0f172a">media_type: character varying(10) ?</text>
+<text x="1844" y="1858" font-family="Courier New, monospace" font-size="11" fill="#0f172a">url: character varying(512) ?</text>
+<text x="1844" y="1874" font-family="Courier New, monospace" font-size="11" fill="#0f172a">sort_order: integer ?</text>
+<text x="1844" y="1890" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="2254" y="1788" width="302" height="80" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="2254" y="1788" width="302" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="2264" y="1808" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">review_tags</text>
+<line x1="2254" y1="1820" x2="2556" y2="1820" stroke="#94a3b8" stroke-width="1" />
+<text x="2264" y="1842" font-family="Courier New, monospace" font-size="11" fill="#0f172a">review_id: bigint ? [PK,FK] -&gt; reviews.id</text>
+<text x="2264" y="1858" font-family="Courier New, monospace" font-size="11" fill="#0f172a">tag_id: bigint ? [PK,FK] -&gt; tags.id</text>
+<rect x="114" y="2148" width="282" height="128" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="114" y="2148" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="124" y="2168" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">review_votes</text>
+<line x1="114" y1="2180" x2="396" y2="2180" stroke="#94a3b8" stroke-width="1" />
+<text x="124" y="2202" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="124" y="2218" font-family="Courier New, monospace" font-size="11" fill="#0f172a">review_id: bigint ? [FK] -&gt; reviews.id</text>
+<text x="124" y="2234" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="124" y="2250" font-family="Courier New, monospace" font-size="11" fill="#0f172a">vote_type: character varying(20) ?</text>
+<text x="124" y="2266" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="530" y="2036" width="309" height="352" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="530" y="2036" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="540" y="2056" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">reviews</text>
+<line x1="530" y1="2068" x2="839" y2="2068" stroke="#94a3b8" stroke-width="1" />
+<text x="540" y="2090" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="540" y="2106" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="540" y="2122" font-family="Courier New, monospace" font-size="11" fill="#0f172a">venue_id: bigint ?</text>
+<text x="540" y="2138" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="540" y="2154" font-family="Courier New, monospace" font-size="11" fill="#0f172a">store_id: bigint ? [FK] -&gt; stores.id</text>
+<text x="540" y="2170" font-family="Courier New, monospace" font-size="11" fill="#0f172a">rating: real ?</text>
+<text x="540" y="2186" font-family="Courier New, monospace" font-size="11" fill="#0f172a">rating_env: real ?</text>
+<text x="540" y="2202" font-family="Courier New, monospace" font-size="11" fill="#0f172a">rating_service: real ?</text>
+<text x="540" y="2218" font-family="Courier New, monospace" font-size="11" fill="#0f172a">rating_value: real ?</text>
+<text x="540" y="2234" font-family="Courier New, monospace" font-size="11" fill="#0f172a">rating_food: real ?</text>
+<text x="540" y="2250" font-family="Courier New, monospace" font-size="11" fill="#0f172a">content: text ?</text>
+<text x="540" y="2266" font-family="Courier New, monospace" font-size="11" fill="#0f172a">images: jsonb ?</text>
+<text x="540" y="2282" font-family="Courier New, monospace" font-size="11" fill="#0f172a">visit_date: date ?</text>
+<text x="540" y="2298" font-family="Courier New, monospace" font-size="11" fill="#0f172a">avg_cost: integer ?</text>
+<text x="540" y="2314" font-family="Courier New, monospace" font-size="11" fill="#0f172a">like_count: integer ?</text>
+<text x="540" y="2330" font-family="Courier New, monospace" font-size="11" fill="#0f172a">comment_count: integer ?</text>
+<text x="540" y="2346" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: smallint ?</text>
+<text x="540" y="2362" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="540" y="2378" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="947" y="2172" width="336" height="80" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="947" y="2172" width="336" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="957" y="2192" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">store_categories</text>
+<line x1="947" y1="2204" x2="1283" y2="2204" stroke="#94a3b8" stroke-width="1" />
+<text x="957" y="2226" font-family="Courier New, monospace" font-size="11" fill="#0f172a">store_id: bigint ? [PK,FK] -&gt; stores.id</text>
+<text x="957" y="2242" font-family="Courier New, monospace" font-size="11" fill="#0f172a">category_id: bigint ? [PK,FK] -&gt; categories.id</text>
+<rect x="1411" y="2140" width="268" height="144" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1411" y="2140" width="268" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1421" y="2160" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">store_hours</text>
+<line x1="1411" y1="2172" x2="1679" y2="2172" stroke="#94a3b8" stroke-width="1" />
+<text x="1421" y="2194" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1421" y="2210" font-family="Courier New, monospace" font-size="11" fill="#0f172a">store_id: bigint ? [FK] -&gt; stores.id</text>
+<text x="1421" y="2226" font-family="Courier New, monospace" font-size="11" fill="#0f172a">day_of_week: smallint ?</text>
+<text x="1421" y="2242" font-family="Courier New, monospace" font-size="11" fill="#0f172a">open_time: character varying(10) ?</text>
+<text x="1421" y="2258" font-family="Courier New, monospace" font-size="11" fill="#0f172a">close_time: character varying(10) ?</text>
+<text x="1421" y="2274" font-family="Courier New, monospace" font-size="11" fill="#0f172a">is_closed: boolean ?</text>
+<rect x="1820" y="2012" width="309" height="400" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1820" y="2012" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1830" y="2032" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">stores</text>
+<line x1="1820" y1="2044" x2="2129" y2="2044" stroke="#94a3b8" stroke-width="1" />
+<text x="1830" y="2066" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="1830" y="2082" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="1830" y="2098" font-family="Courier New, monospace" font-size="11" fill="#0f172a">name: character varying(255) ?</text>
+<text x="1830" y="2114" font-family="Courier New, monospace" font-size="11" fill="#0f172a">description: text ?</text>
+<text x="1830" y="2130" font-family="Courier New, monospace" font-size="11" fill="#0f172a">address: character varying(255) ?</text>
+<text x="1830" y="2146" font-family="Courier New, monospace" font-size="11" fill="#0f172a">city: character varying(100) ?</text>
+<text x="1830" y="2162" font-family="Courier New, monospace" font-size="11" fill="#0f172a">state: character varying(100) ?</text>
+<text x="1830" y="2178" font-family="Courier New, monospace" font-size="11" fill="#0f172a">zip_code: character varying(20) ?</text>
+<text x="1830" y="2194" font-family="Courier New, monospace" font-size="11" fill="#0f172a">country: character varying(50) ?</text>
+<text x="1830" y="2210" font-family="Courier New, monospace" font-size="11" fill="#0f172a">phone: character varying(50) ?</text>
+<text x="1830" y="2226" font-family="Courier New, monospace" font-size="11" fill="#0f172a">website: character varying(255) ?</text>
+<text x="1830" y="2242" font-family="Courier New, monospace" font-size="11" fill="#0f172a">latitude: double precision ?</text>
+<text x="1830" y="2258" font-family="Courier New, monospace" font-size="11" fill="#0f172a">longitude: double precision ?</text>
+<text x="1830" y="2274" font-family="Courier New, monospace" font-size="11" fill="#0f172a">cover_image_url: character varying(255) ?</text>
+<text x="1830" y="2290" font-family="Courier New, monospace" font-size="11" fill="#0f172a">images: jsonb ?</text>
+<text x="1830" y="2306" font-family="Courier New, monospace" font-size="11" fill="#0f172a">avg_rating: numeric(3,2) ?</text>
+<text x="1830" y="2322" font-family="Courier New, monospace" font-size="11" fill="#0f172a">review_count: integer ?</text>
+<text x="1830" y="2338" font-family="Courier New, monospace" font-size="11" fill="#0f172a">follower_count: integer ?</text>
+<text x="1830" y="2354" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: smallint ?</text>
+<text x="1830" y="2370" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="1830" y="2386" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<text x="1830" y="2402" font-family="Courier New, monospace" font-size="11" fill="#0f172a">deleted_at: timestamp with time zone ?</text>
+<rect x="2264" y="2140" width="282" height="144" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="2264" y="2140" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="2274" y="2160" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">tags</text>
+<line x1="2264" y1="2172" x2="2546" y2="2172" stroke="#94a3b8" stroke-width="1" />
+<text x="2274" y="2194" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="2274" y="2210" font-family="Courier New, monospace" font-size="11" fill="#0f172a">name: character varying(50) ?</text>
+<text x="2274" y="2226" font-family="Courier New, monospace" font-size="11" fill="#0f172a">type: character varying(20) ?</text>
+<text x="2274" y="2242" font-family="Courier New, monospace" font-size="11" fill="#0f172a">post_count: integer ?</text>
+<text x="2274" y="2258" font-family="Courier New, monospace" font-size="11" fill="#0f172a">review_count: integer ?</text>
+<text x="2274" y="2274" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="114" y="2444" width="282" height="240" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="114" y="2444" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="124" y="2464" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">user_addresses</text>
+<line x1="114" y1="2476" x2="396" y2="2476" stroke="#94a3b8" stroke-width="1" />
+<text x="124" y="2498" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="124" y="2514" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="124" y="2530" font-family="Courier New, monospace" font-size="11" fill="#0f172a">name: character varying(50) ?</text>
+<text x="124" y="2546" font-family="Courier New, monospace" font-size="11" fill="#0f172a">phone: character varying(20) ?</text>
+<text x="124" y="2562" font-family="Courier New, monospace" font-size="11" fill="#0f172a">province: character varying(50) ?</text>
+<text x="124" y="2578" font-family="Courier New, monospace" font-size="11" fill="#0f172a">city: character varying(100) ?</text>
+<text x="124" y="2594" font-family="Courier New, monospace" font-size="11" fill="#0f172a">district: character varying(50) ?</text>
+<text x="124" y="2610" font-family="Courier New, monospace" font-size="11" fill="#0f172a">address: character varying(255) ?</text>
+<text x="124" y="2626" font-family="Courier New, monospace" font-size="11" fill="#0f172a">postal_code: character varying(20) ?</text>
+<text x="124" y="2642" font-family="Courier New, monospace" font-size="11" fill="#0f172a">is_default: boolean ?</text>
+<text x="124" y="2658" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="124" y="2674" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="523" y="2492" width="323" height="144" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="523" y="2492" width="323" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="533" y="2512" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">user_auths</text>
+<line x1="523" y1="2524" x2="846" y2="2524" stroke="#94a3b8" stroke-width="1" />
+<text x="533" y="2546" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="533" y="2562" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id, users.id</text>
+<text x="533" y="2578" font-family="Courier New, monospace" font-size="11" fill="#0f172a">identity_type: character varying(20) ?</text>
+<text x="533" y="2594" font-family="Courier New, monospace" font-size="11" fill="#0f172a">identifier: character varying(255) ?</text>
+<text x="533" y="2610" font-family="Courier New, monospace" font-size="11" fill="#0f172a">credential: character varying(255) ?</text>
+<text x="533" y="2626" font-family="Courier New, monospace" font-size="11" fill="#0f172a">last_login_at: timestamp with time zone ?</text>
+<rect x="970" y="2508" width="289" height="112" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="970" y="2508" width="289" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="980" y="2528" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">user_follows</text>
+<line x1="970" y1="2540" x2="1259" y2="2540" stroke="#94a3b8" stroke-width="1" />
+<text x="980" y="2562" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="980" y="2578" font-family="Courier New, monospace" font-size="11" fill="#0f172a">follower_id: bigint ? [FK] -&gt; users.id</text>
+<text x="980" y="2594" font-family="Courier New, monospace" font-size="11" fill="#0f172a">following_id: bigint ? [FK] -&gt; users.id</text>
+<text x="980" y="2610" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<rect x="1407" y="2516" width="275" height="96" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1407" y="2516" width="275" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1417" y="2536" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">user_notifications</text>
+<line x1="1407" y1="2548" x2="1682" y2="2548" stroke="#94a3b8" stroke-width="1" />
+<text x="1417" y="2570" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [PK,FK] -&gt; users.id</text>
+<text x="1417" y="2586" font-family="Courier New, monospace" font-size="11" fill="#0f172a">push_enabled: boolean ?</text>
+<text x="1417" y="2602" font-family="Courier New, monospace" font-size="11" fill="#0f172a">email_enabled: boolean ?</text>
+<rect x="1837" y="2524" width="275" height="80" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="1837" y="2524" width="275" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="1847" y="2544" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">user_privacies</text>
+<line x1="1837" y1="2556" x2="2112" y2="2556" stroke="#94a3b8" stroke-width="1" />
+<text x="1847" y="2578" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [PK,FK] -&gt; users.id</text>
+<text x="1847" y="2594" font-family="Courier New, monospace" font-size="11" fill="#0f172a">is_public: boolean ?</text>
+<rect x="2233" y="2452" width="343" height="224" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="2233" y="2452" width="343" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="2243" y="2472" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">user_profiles</text>
+<line x1="2233" y1="2484" x2="2576" y2="2484" stroke="#94a3b8" stroke-width="1" />
+<text x="2243" y="2506" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [PK,FK] -&gt; users.id, users.id</text>
+<text x="2243" y="2522" font-family="Courier New, monospace" font-size="11" fill="#0f172a">nickname: character varying(50) ?</text>
+<text x="2243" y="2538" font-family="Courier New, monospace" font-size="11" fill="#0f172a">avatar_url: character varying(255) ?</text>
+<text x="2243" y="2554" font-family="Courier New, monospace" font-size="11" fill="#0f172a">intro: character varying(255) ?</text>
+<text x="2243" y="2570" font-family="Courier New, monospace" font-size="11" fill="#0f172a">location: character varying(100) ?</text>
+<text x="2243" y="2586" font-family="Courier New, monospace" font-size="11" fill="#0f172a">follower_count: integer ?</text>
+<text x="2243" y="2602" font-family="Courier New, monospace" font-size="11" fill="#0f172a">following_count: integer ?</text>
+<text x="2243" y="2618" font-family="Courier New, monospace" font-size="11" fill="#0f172a">post_count: integer ?</text>
+<text x="2243" y="2634" font-family="Courier New, monospace" font-size="11" fill="#0f172a">review_count: integer ?</text>
+<text x="2243" y="2650" font-family="Courier New, monospace" font-size="11" fill="#0f172a">like_count: integer ?</text>
+<text x="2243" y="2666" font-family="Courier New, monospace" font-size="11" fill="#0f172a">coupon_count: integer ?</text>
+<rect x="114" y="2812" width="282" height="128" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="114" y="2812" width="282" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="124" y="2832" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">users</text>
+<line x1="114" y1="2844" x2="396" y2="2844" stroke="#94a3b8" stroke-width="1" />
+<text x="124" y="2866" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="124" y="2882" font-family="Courier New, monospace" font-size="11" fill="#0f172a">role: character varying(20) ?</text>
+<text x="124" y="2898" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: smallint ?</text>
+<text x="124" y="2914" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="124" y="2930" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+<rect x="530" y="2716" width="309" height="320" rx="8" ry="8" fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />
+<rect x="530" y="2716" width="309" height="32" rx="8" ry="8" fill="#e2e8f0" stroke="none" />
+<text x="540" y="2736" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#0f172a">vouchers</text>
+<line x1="530" y1="2748" x2="839" y2="2748" stroke="#94a3b8" stroke-width="1" />
+<text x="540" y="2770" font-family="Courier New, monospace" font-size="11" fill="#0f172a">id: bigint ? [PK]</text>
+<text x="540" y="2786" font-family="Courier New, monospace" font-size="11" fill="#0f172a">code: character varying(50) ?</text>
+<text x="540" y="2802" font-family="Courier New, monospace" font-size="11" fill="#0f172a">coupon_id: bigint ? [FK] -&gt; coupons.id</text>
+<text x="540" y="2818" font-family="Courier New, monospace" font-size="11" fill="#0f172a">user_id: bigint ? [FK] -&gt; users.id</text>
+<text x="540" y="2834" font-family="Courier New, monospace" font-size="11" fill="#0f172a">package_id: bigint ? [FK] -&gt; packages.id</text>
+<text x="540" y="2850" font-family="Courier New, monospace" font-size="11" fill="#0f172a">order_id: bigint ? [FK] -&gt; orders.id</text>
+<text x="540" y="2866" font-family="Courier New, monospace" font-size="11" fill="#0f172a">merchant_id: bigint ? [FK] -&gt; merchants.id</text>
+<text x="540" y="2882" font-family="Courier New, monospace" font-size="11" fill="#0f172a">status: character varying(20) ?</text>
+<text x="540" y="2898" font-family="Courier New, monospace" font-size="11" fill="#0f172a">expiry_date: timestamp with time zone ?</text>
+<text x="540" y="2914" font-family="Courier New, monospace" font-size="11" fill="#0f172a">valid_from: timestamp with time zone ?</text>
+<text x="540" y="2930" font-family="Courier New, monospace" font-size="11" fill="#0f172a">valid_until: timestamp with time zone ?</text>
+<text x="540" y="2946" font-family="Courier New, monospace" font-size="11" fill="#0f172a">redeemed_at: timestamp with time zone ?</text>
+<text x="540" y="2962" font-family="Courier New, monospace" font-size="11" fill="#0f172a">redeemed_by: bigint ? [FK] -&gt; users.id</text>
+<text x="540" y="2978" font-family="Courier New, monospace" font-size="11" fill="#0f172a">redemption_note: text ?</text>
+<text x="540" y="2994" font-family="Courier New, monospace" font-size="11" fill="#0f172a">qr_code: character varying(255) ?</text>
+<text x="540" y="3010" font-family="Courier New, monospace" font-size="11" fill="#0f172a">created_at: timestamp with time zone ?</text>
+<text x="540" y="3026" font-family="Courier New, monospace" font-size="11" fill="#0f172a">updated_at: timestamp with time zone ?</text>
+</svg>

--- a/docs/testing/all-api-test-cases-v1.md
+++ b/docs/testing/all-api-test-cases-v1.md
@@ -5085,3 +5085,62 @@ PATCH /api/v1/vouchers/1/use
 
 ---
 
+## 实测补充记录（2026-03-04）
+
+- 执行人：Codex（本地服务联调）
+- 环境 API：`http://127.0.0.1:8080/api/v1`
+- 环境 DB：`10.0.0.1:5432/revieu`
+- 测试账号：`ethanlee0302@proton.me`
+- 测试目标：验证 `store/coupon` 删除链路与软删除落库状态，补充验证 `user` 删除时的级联行为
+
+### 1) Store/Coupon 删除链路（实测）
+
+| 步骤 | API | 输入摘要 | HTTP | 关键输出 |
+|---|---|---|---|---|
+| 1 | `POST /auth/login` | email/password 登录 | `200` | 获取 `access_token` |
+| 2 | `POST /merchant/stores` | 创建测试门店 | `201` | `store_id=233` |
+| 3 | `POST /merchant/stores/233/activate` | 激活门店 | `200` | `{"status":"ok"}` |
+| 4 | `POST /merchant/stores/233/coupons` | 创建券 | `201` | `coupon_id=5` |
+| 5 | `POST /coupons/5/validate` | `{"quantity":1}` | `400` | `{"error":"coupon inactive"}` |
+| 6 | `DELETE /merchant/stores/233/coupons/5` | 删除券 | `200` | `{"status":"ok"}` |
+| 7 | `POST /coupons/5/validate` | `{"quantity":1}` | `404` | `{"error":"not found"}` |
+| 8 | `POST /merchant/stores/233/coupons` | 再创建券 | `201` | `coupon_id=6` |
+| 9 | `DELETE /merchant/stores/233` | 删除门店 | `200` | `{"status":"ok"}` |
+| 10 | `POST /coupons/6/validate` | `{"quantity":1}` | `404` | `{"error":"not found"}` |
+| 11 | `GET /stores/233/coupons` | 读取门店券列表 | `404` | `{"error":"not found"}` |
+
+### 2) 数据库结果核验（实测）
+
+执行 SQL（关键检查）：
+
+```sql
+SELECT id, (deleted_at IS NOT NULL) AS soft_deleted FROM stores WHERE id IN (233);
+SELECT id, store_id, (deleted_at IS NOT NULL) AS soft_deleted FROM coupons WHERE id IN (5,6) ORDER BY id;
+SELECT id, user_id, (deleted_at IS NOT NULL) AS soft_deleted FROM merchants WHERE id IN (203);
+```
+
+结果：
+
+- `stores.id=233` -> `soft_deleted=true`
+- `coupons.id=5` -> `soft_deleted=true`
+- `coupons.id=6` -> `soft_deleted=true`
+- `merchants.id=203` -> `soft_deleted=false`
+
+结论：
+
+- `DELETE /merchant/stores/:id` 会对该门店和其关联券执行软删除（符合当前实现）。
+- `DELETE /merchant/stores/:id/coupons/:couponId` 可独立软删除单券（符合当前实现）。
+
+### 3) User 删除级联验证（事务回滚，不污染数据）
+
+验证方式：在单个事务里临时创建 `user -> merchant -> store -> coupon`，删除 `user` 后观察，再 `ROLLBACK`。
+
+关键观察：
+
+- 删除 `user` 后，`merchants.user_id` 变为 `NULL`。
+- 该 `merchant` 下 `stores/coupons` 记录仍保留（不会自动删除）。
+
+结论：
+
+- 当前数据库约束是 `merchants.user_id -> users.id ON DELETE SET NULL`。
+- 当前行为不是 `user` 级联删除商家链路，需要通过业务逻辑补齐“用户删除时的 merchant/store/coupon 软删除”。

--- a/scripts/generate_db_erd_svg.py
+++ b/scripts/generate_db_erd_svg.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""
+Generate a full PostgreSQL ERD SVG with PK/FK markers.
+
+Example:
+  python scripts/generate_db_erd_svg.py \
+    --host 10.0.0.1 --user postgres --db revieu --password 123456 \
+    --output docs/database-erd.svg
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+
+
+@dataclass
+class Column:
+    name: str
+    data_type: str
+    not_null: bool
+
+
+@dataclass
+class FK:
+    constraint: str
+    table: str
+    column: str
+    ref_table: str
+    ref_column: str
+
+
+def run_psql(host: str, user: str, db: str, password: str, sql: str) -> list[str]:
+    env = os.environ.copy()
+    env["PGPASSWORD"] = password
+    cmd = [
+        "psql",
+        "-h",
+        host,
+        "-U",
+        user,
+        "-d",
+        db,
+        "-At",
+        "-F",
+        "\t",
+        "-c",
+        sql,
+    ]
+    result = subprocess.run(
+        cmd,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "psql failed")
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def load_schema(host: str, user: str, db: str, password: str):
+    tables = run_psql(
+        host,
+        user,
+        db,
+        password,
+        """
+        SELECT c.relname
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public' AND c.relkind = 'r'
+        ORDER BY c.relname;
+        """,
+    )
+
+    col_rows = run_psql(
+        host,
+        user,
+        db,
+        password,
+        """
+        SELECT c.relname,
+               a.attnum,
+               a.attname,
+               pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+               a.attnotnull::text
+        FROM pg_attribute a
+        JOIN pg_class c ON c.oid = a.attrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+        ORDER BY c.relname, a.attnum;
+        """,
+    )
+
+    pk_rows = run_psql(
+        host,
+        user,
+        db,
+        password,
+        """
+        SELECT c.conrelid::regclass::text AS table_name,
+               a.attname AS column_name
+        FROM pg_constraint c
+        JOIN unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+        JOIN pg_namespace n ON n.oid = c.connamespace
+        WHERE c.contype = 'p' AND n.nspname = 'public'
+        ORDER BY table_name, k.ord;
+        """,
+    )
+
+    fk_rows = run_psql(
+        host,
+        user,
+        db,
+        password,
+        """
+        SELECT con.conname,
+               con.conrelid::regclass::text AS table_name,
+               src.attname AS column_name,
+               con.confrelid::regclass::text AS ref_table,
+               tgt.attname AS ref_column
+        FROM pg_constraint con
+        JOIN pg_namespace n ON n.oid = con.connamespace
+        JOIN generate_subscripts(con.conkey, 1) AS s(i) ON TRUE
+        JOIN pg_attribute src ON src.attrelid = con.conrelid AND src.attnum = con.conkey[s.i]
+        JOIN pg_attribute tgt ON tgt.attrelid = con.confrelid AND tgt.attnum = con.confkey[s.i]
+        WHERE con.contype = 'f' AND n.nspname = 'public'
+        ORDER BY table_name, con.conname, s.i;
+        """,
+    )
+
+    columns: dict[str, list[Column]] = defaultdict(list)
+    for row in col_rows:
+        table, _attnum, name, data_type, notnull_txt = row.split("\t")
+        columns[table].append(
+            Column(name=name, data_type=data_type, not_null=(notnull_txt == "t"))
+        )
+
+    pk_cols: set[tuple[str, str]] = set()
+    for row in pk_rows:
+        table, column = row.split("\t")
+        pk_cols.add((table, column))
+
+    fks: list[FK] = []
+    fks_by_col: dict[tuple[str, str], list[FK]] = defaultdict(list)
+    for row in fk_rows:
+        conname, table, column, ref_table, ref_column = row.split("\t")
+        fk = FK(
+            constraint=conname,
+            table=table,
+            column=column,
+            ref_table=ref_table,
+            ref_column=ref_column,
+        )
+        fks.append(fk)
+        fks_by_col[(table, column)].append(fk)
+
+    return tables, columns, pk_cols, fks, fks_by_col
+
+
+def make_svg(
+    tables: list[str],
+    columns: dict[str, list[Column]],
+    pk_cols: set[tuple[str, str]],
+    fks: list[FK],
+    fks_by_col: dict[tuple[str, str], list[FK]],
+) -> str:
+    ncols = 6
+    margin_x = 40
+    margin_y = 140
+    col_width = 430
+    row_gap = 32
+    line_h = 16
+    header_h = 28
+    node_pad = 10
+
+    node_meta = {}
+    row_heights: list[int] = []
+
+    for idx, table in enumerate(tables):
+        lines = []
+        col_index = {}
+        max_chars = len(table) + 4
+        for i, col in enumerate(columns.get(table, [])):
+            col_index[col.name] = i
+            markers = []
+            if (table, col.name) in pk_cols:
+                markers.append("PK")
+            if (table, col.name) in fks_by_col:
+                markers.append("FK")
+            marker_txt = f" [{','.join(markers)}]" if markers else ""
+            fk_targets = ""
+            if (table, col.name) in fks_by_col:
+                refs = ", ".join(
+                    f"{fk.ref_table}.{fk.ref_column}"
+                    for fk in fks_by_col[(table, col.name)]
+                )
+                fk_targets = f" -> {refs}"
+            null_txt = "" if col.not_null else " ?"
+            line = f"{col.name}: {col.data_type}{null_txt}{marker_txt}{fk_targets}"
+            lines.append(line)
+            max_chars = max(max_chars, len(line))
+
+        width = min(max(250, int(max_chars * 6.8) + 24), 410)
+        height = header_h + len(lines) * line_h + node_pad * 2
+        row = idx // ncols
+        while len(row_heights) <= row:
+            row_heights.append(0)
+        row_heights[row] = max(row_heights[row], height)
+        node_meta[table] = {
+            "idx": idx,
+            "row": row,
+            "col": idx % ncols,
+            "width": width,
+            "height": height,
+            "lines": lines,
+            "col_index": col_index,
+        }
+
+    row_offsets = []
+    y = margin_y
+    for h in row_heights:
+        row_offsets.append(y)
+        y += h + row_gap
+
+    total_width = margin_x * 2 + ncols * col_width
+    total_height = y + 40
+
+    for table in tables:
+        meta = node_meta[table]
+        col = meta["col"]
+        row = meta["row"]
+        w = meta["width"]
+        h = meta["height"]
+        x = margin_x + col * col_width + (col_width - w) // 2
+        y0 = row_offsets[row] + (row_heights[row] - h) // 2
+        meta["x"] = x
+        meta["y"] = y0
+
+    def anchor(table: str, column: str, side_hint: str):
+        meta = node_meta[table]
+        x = meta["x"]
+        y0 = meta["y"]
+        w = meta["width"]
+        idx = meta["col_index"].get(column, 0)
+        y = y0 + header_h + node_pad + int((idx + 0.6) * line_h)
+        if side_hint == "left":
+            return x, y
+        if side_hint == "right":
+            return x + w, y
+        return x + w // 2, y
+
+    svg_parts = []
+    svg_parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{total_width}" '
+        f'height="{total_height}" viewBox="0 0 {total_width} {total_height}">'
+    )
+    svg_parts.append(
+        "<defs>"
+        '<marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" '
+        'orient="auto" markerUnits="strokeWidth">'
+        '<path d="M0,0 L0,6 L9,3 z" fill="#64748b" />'
+        "</marker>"
+        "</defs>"
+    )
+    svg_parts.append(
+        f'<rect x="0" y="0" width="{total_width}" height="{total_height}" fill="#f8fafc" />'
+    )
+
+    title = "RevieU Database ERD (public schema)"
+    subtitle = f"Tables: {len(tables)} | FK relationships: {len(fks)} | PK/FK markers shown per column"
+    svg_parts.append(
+        f'<text x="{margin_x}" y="40" font-family="Arial, sans-serif" font-size="24" '
+        f'font-weight="700" fill="#0f172a">{html.escape(title)}</text>'
+    )
+    svg_parts.append(
+        f'<text x="{margin_x}" y="66" font-family="Arial, sans-serif" font-size="13" '
+        f'fill="#334155">{html.escape(subtitle)}</text>'
+    )
+    svg_parts.append(
+        f'<text x="{margin_x}" y="88" font-family="Arial, sans-serif" font-size="12" '
+        f'fill="#334155">Legend: [PK] primary key, [FK] foreign key, "?" nullable column</text>'
+    )
+
+    # Draw edges first.
+    for fk in fks:
+        s_meta = node_meta[fk.table]
+        t_meta = node_meta[fk.ref_table]
+        s_cx = s_meta["x"] + s_meta["width"] / 2
+        t_cx = t_meta["x"] + t_meta["width"] / 2
+
+        if s_cx < t_cx:
+            sx, sy = anchor(fk.table, fk.column, "right")
+            tx, ty = anchor(fk.ref_table, fk.ref_column, "left")
+        elif s_cx > t_cx:
+            sx, sy = anchor(fk.table, fk.column, "left")
+            tx, ty = anchor(fk.ref_table, fk.ref_column, "right")
+        else:
+            s_top = s_meta["y"]
+            t_top = t_meta["y"]
+            if s_top < t_top:
+                sx, sy = anchor(fk.table, fk.column, "center")
+                tx, ty = anchor(fk.ref_table, fk.ref_column, "center")
+                sy = s_meta["y"] + s_meta["height"]
+                ty = t_meta["y"]
+            else:
+                sx, sy = anchor(fk.table, fk.column, "center")
+                tx, ty = anchor(fk.ref_table, fk.ref_column, "center")
+                sy = s_meta["y"]
+                ty = t_meta["y"] + t_meta["height"]
+
+        if abs(sx - tx) >= abs(sy - ty):
+            mx = (sx + tx) / 2
+            path = f"M {sx:.1f} {sy:.1f} C {mx:.1f} {sy:.1f}, {mx:.1f} {ty:.1f}, {tx:.1f} {ty:.1f}"
+        else:
+            my = (sy + ty) / 2
+            path = f"M {sx:.1f} {sy:.1f} C {sx:.1f} {my:.1f}, {tx:.1f} {my:.1f}, {tx:.1f} {ty:.1f}"
+
+        edge_title = f"{fk.table}.{fk.column} -> {fk.ref_table}.{fk.ref_column} ({fk.constraint})"
+        svg_parts.append(
+            f'<path d="{path}" stroke="#64748b" stroke-opacity="0.45" stroke-width="1.1" '
+            f'fill="none" marker-end="url(#arrow)"><title>{html.escape(edge_title)}</title></path>'
+        )
+
+    # Draw table nodes.
+    for table in tables:
+        meta = node_meta[table]
+        x = meta["x"]
+        y0 = meta["y"]
+        w = meta["width"]
+        h = meta["height"]
+        lines = meta["lines"]
+
+        svg_parts.append(
+            f'<rect x="{x}" y="{y0}" width="{w}" height="{h}" rx="8" ry="8" '
+            'fill="#ffffff" stroke="#0f172a" stroke-opacity="0.25" />'
+        )
+        svg_parts.append(
+            f'<rect x="{x}" y="{y0}" width="{w}" height="{header_h + 4}" rx="8" ry="8" '
+            'fill="#e2e8f0" stroke="none" />'
+        )
+        svg_parts.append(
+            f'<text x="{x + 10}" y="{y0 + 20}" font-family="Arial, sans-serif" '
+            f'font-size="14" font-weight="700" fill="#0f172a">{html.escape(table)}</text>'
+        )
+        svg_parts.append(
+            f'<line x1="{x}" y1="{y0 + header_h + 4}" x2="{x + w}" y2="{y0 + header_h + 4}" '
+            'stroke="#94a3b8" stroke-width="1" />'
+        )
+
+        for i, line in enumerate(lines):
+            ty = y0 + header_h + node_pad + (i + 1) * line_h
+            svg_parts.append(
+                f'<text x="{x + 10}" y="{ty}" font-family="Courier New, monospace" '
+                f'font-size="11" fill="#0f172a">{html.escape(line)}</text>'
+            )
+
+    svg_parts.append("</svg>")
+    return "\n".join(svg_parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate PostgreSQL ERD SVG")
+    parser.add_argument("--host", required=True, help="PostgreSQL host")
+    parser.add_argument("--user", required=True, help="PostgreSQL user")
+    parser.add_argument("--db", required=True, help="PostgreSQL database")
+    parser.add_argument("--password", required=True, help="PostgreSQL password")
+    parser.add_argument("--output", default="docs/database-erd.svg", help="Output SVG path")
+    args = parser.parse_args()
+
+    tables, columns, pk_cols, fks, fks_by_col = load_schema(
+        host=args.host,
+        user=args.user,
+        db=args.db,
+        password=args.password,
+    )
+    svg = make_svg(
+        tables=tables,
+        columns=columns,
+        pk_cols=pk_cols,
+        fks=fks,
+        fks_by_col=fks_by_col,
+    )
+    out_path = args.output
+    out_dir = os.path.dirname(out_path) or "."
+    os.makedirs(out_dir, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(svg)
+
+    print(f"Generated: {out_path}")
+    print(f"Tables: {len(tables)}")
+    print(f"FK columns: {len(fks)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
## Summary
This PR delivers two connected tracks:

1. Merchant/Store/Coupon soft-delete deletion baseline (issues #173-#177)
2. Account deletion execution cascade for user-owned merchant data (issue #178)

It also adds a generated full-schema database ERD SVG and regeneration script for team visibility.

## Linked Issues
- Closes #173
- Closes #174
- Closes #175
- Closes #176
- Closes #177
- Closes #178

## Scope
### A) Merchant / Store / Coupon delete flows
- Added soft-delete foundation for `merchants`, `stores`, `coupons` via migration:
  - `apps/core/migrations/00002_add_soft_delete_to_merchant_store_coupon.sql`
- Added owner-guarded delete APIs:
  - `DELETE /api/v1/merchant/stores/:id`
  - `DELETE /api/v1/merchant/stores/:id/coupons/:couponId`
- Added placeholder endpoint (forward-compatible):
  - `DELETE /api/v1/merchant/me` -> `501 not implemented`
- Added service-level transactional behavior for store delete:
  - soft-delete bound coupons, soft-delete store, decrement `merchant.total_stores` safely
- Kept voucher merchant redeem compatible with soft-deleted coupons.

### B) User account deletion execution (#178)
- Kept API request semantics for `DELETE /api/v1/user/account` (schedule + cooling period).
- Implemented due-deletion executor in user service:
  - scans due `account_deletions`
  - per-user transactional execution with row lock
  - soft-deletes owned `merchant/store/coupon`
  - explicitly deletes `user_auths` / `user_profiles` before deleting `users`
  - clears processed `account_deletions`
  - idempotent retry behavior
- Wired background executor in app startup:
  - run once at boot
  - run every 1 minute

### C) Documentation / observability
- Regenerated swagger docs for new/updated endpoint semantics.
- Added full DB ERD output and generator:
  - `docs/database-erd.svg`
  - `scripts/generate_db_erd_svg.py`
- Added README reference and regeneration command.
- Appended integration test evidence into:
  - `docs/testing/all-api-test-cases-v1.md`

## API & Behavior Changes
### New/updated merchant endpoints
- `DELETE /merchant/stores/{id}`
- `DELETE /merchant/stores/{id}/coupons/{couponId}`
- `DELETE /merchant/me` (placeholder 501)

### User account deletion behavior
- `DELETE /user/account` still returns scheduled response.
- Actual cascade execution now happens asynchronously via internal background worker.

## Database / Migration Impact
### Required migration
- `00002_add_soft_delete_to_merchant_store_coupon.sql`
- Adds:
  - `merchants.deleted_at` + index
  - `stores.deleted_at` + index
  - `coupons.deleted_at` + index

No destructive schema drop in this PR's rollout path.

## Verification Evidence
### Automated
- `GOCACHE=/tmp/go-build go test ./internal/domain/user/...`
- `GOCACHE=/tmp/go-build go test ./cmd/app`
- Added focused tests for:
  - store/coupon delete ownership and idempotency
  - voucher redeem compatibility on soft-deleted coupons
  - user account deletion cascade and retry safety

### Manual integration (shared DB)
- Local server booted against `10.0.0.1` and executor startup confirmed.
- E2E API checks validated soft-delete visibility gates (`404` after deletion).
- Real due-account-deletion integration run validated:
  - `users` row removed
  - `account_deletions` row removed
  - related `merchant/store/coupon` soft-deleted (`deleted_at IS NOT NULL`)

## Risks / Notes
- Background executor currently runs in-process every minute; multiple replicas rely on row-lock + idempotent execution to avoid double-processing side effects.
- Existing production FK drift (`NO ACTION` on some user relations) is handled by explicit dependent cleanup before deleting user row.

## Rollback
- Code rollback is straightforward.
- Schema rollback for soft-delete columns is available in migration down section, but production rollback should be evaluated carefully before dropping columns.

## Checklist
- [x] API behavior implemented
- [x] Tests added/updated
- [x] Swagger regenerated
- [x] Migration included
- [x] README/docs updated
- [x] Branch pushed and ready to merge into `dev`
