### PR TITLE
feat(merchant): add search query parameter to list endpoint

### DIFF
--- a/apps/core/docs/docs.go
+++ b/apps/core/docs/docs.go
@@ -1155,12 +1155,29 @@ const docTemplate = `{
                     "store"
                 ],
                 "summary": "List current merchant stores",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page size (max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "401": {
@@ -2052,6 +2069,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Category filter",
                         "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search by name",
+                        "name": "search",
                         "in": "query"
                     }
                 ],

--- a/apps/core/docs/swagger.json
+++ b/apps/core/docs/swagger.json
@@ -1153,12 +1153,29 @@
                     "store"
                 ],
                 "summary": "List current merchant stores",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page size (max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "401": {
@@ -2050,6 +2067,12 @@
                         "type": "string",
                         "description": "Category filter",
                         "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search by name",
+                        "name": "search",
                         "in": "query"
                     }
                 ],

--- a/apps/core/docs/swagger.yaml
+++ b/apps/core/docs/swagger.yaml
@@ -1289,6 +1289,11 @@ paths:
   /merchant/stores:
     get:
       description: Returns stores owned by the authenticated merchant user
+      parameters:
+      - description: Page size (max 100)
+        in: query
+        name: limit
+        type: integer
       produces:
       - application/json
       responses:
@@ -1296,6 +1301,12 @@ paths:
           description: OK
           schema:
             additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
             type: object
         "401":
           description: Unauthorized
@@ -1875,6 +1886,10 @@ paths:
       - description: Category filter
         in: query
         name: category
+        type: string
+      - description: Search by name
+        in: query
+        name: search
         type: string
       produces:
       - application/json

--- a/apps/core/internal/domain/merchant/handler/merchant.go
+++ b/apps/core/internal/domain/merchant/handler/merchant.go
@@ -28,12 +28,14 @@ func NewMerchantHandler(svc *service.MerchantService) *MerchantHandler {
 // @Tags merchant
 // @Produce json
 // @Param category query string false "Category filter"
+// @Param search query string false "Search by name"
 // @Success 200 {object} map[string]interface{}
 // @Failure 500 {object} map[string]string
 // @Router /merchants [get]
 func (h *MerchantHandler) List(c *gin.Context) {
 	category := c.Query("category")
-	merchants, err := h.svc.List(c.Request.Context(), category)
+	search := c.Query("search")
+	merchants, err := h.svc.List(c.Request.Context(), category, search)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/apps/core/internal/domain/merchant/service/service.go
+++ b/apps/core/internal/domain/merchant/service/service.go
@@ -22,10 +22,14 @@ func NewMerchantService(db *gorm.DB) *MerchantService {
 	return &MerchantService{db: db}
 }
 
-func (s *MerchantService) List(ctx context.Context, category string) ([]model.Merchant, error) {
+func (s *MerchantService) List(ctx context.Context, category, search string) ([]model.Merchant, error) {
 	q := s.publicScope(s.db.WithContext(ctx).Model(&model.Merchant{}))
 	if category != "" {
 		q = q.Where("category = ?", category)
+	}
+	if search != "" {
+		pattern := "%" + search + "%"
+		q = q.Where("name ILIKE ? OR business_name ILIKE ?", pattern, pattern)
 	}
 	var merchants []model.Merchant
 	if err := q.Order("id desc").Find(&merchants).Error; err != nil {


### PR DESCRIPTION
## Summary
- Add `?search=` query parameter to `GET /merchants` endpoint
- Case-insensitive ILIKE matching on `name` and `business_name` columns
- Supports combined filtering with existing `?category=` parameter

## Related
Closes #188
Frontend counterpart: RevieU-Corp/revieu-web#163

## Test plan
- [ ] `GET /merchants?search=pizza` returns matching merchants
- [ ] `GET /merchants?search=pizza&category=restaurant` combines both filters
- [ ] `GET /merchants` without search param still returns all merchants (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)