### PR TITLE
feat(core): add store menu_images support (#190)

### DIFF
--- a/apps/core/docs/docs.go
+++ b/apps/core/docs/docs.go
@@ -964,7 +964,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLRequest"
+                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLRequest"
                         }
                     }
                 ],
@@ -972,7 +972,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLResponse"
+                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLResponse"
                         }
                     },
                     "400": {
@@ -4978,7 +4978,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.FileRequest": {
+        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.FileRequest": {
             "type": "object",
             "properties": {
                 "content_type": {
@@ -4989,29 +4989,29 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLRequest": {
+        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLRequest": {
             "type": "object",
             "properties": {
                 "files": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.FileRequest"
+                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.FileRequest"
                     }
                 }
             }
         },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLResponse": {
+        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLResponse": {
             "type": "object",
             "properties": {
                 "uploads": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.UploadInfo"
+                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.UploadInfo"
                     }
                 }
             }
         },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.UploadInfo": {
+        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.UploadInfo": {
             "type": "object",
             "properties": {
                 "expires_at": {
@@ -5240,6 +5240,12 @@ const docTemplate = `{
                 "longitude": {
                     "type": "number"
                 },
+                "menu_images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "name": {
                     "type": "string",
                     "maxLength": 255
@@ -5327,6 +5333,12 @@ const docTemplate = `{
                 },
                 "longitude": {
                     "type": "number"
+                },
+                "menu_images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string",

--- a/apps/core/docs/swagger.json
+++ b/apps/core/docs/swagger.json
@@ -962,7 +962,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLRequest"
+                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLRequest"
                         }
                     }
                 ],
@@ -970,7 +970,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLResponse"
+                            "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLResponse"
                         }
                     },
                     "400": {
@@ -4976,7 +4976,7 @@
         }
     },
     "definitions": {
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.FileRequest": {
+        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.FileRequest": {
             "type": "object",
             "properties": {
                 "content_type": {
@@ -4987,29 +4987,29 @@
                 }
             }
         },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLRequest": {
+        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLRequest": {
             "type": "object",
             "properties": {
                 "files": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.FileRequest"
+                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.FileRequest"
                     }
                 }
             }
         },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLResponse": {
+        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLResponse": {
             "type": "object",
             "properties": {
                 "uploads": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.UploadInfo"
+                        "$ref": "#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.UploadInfo"
                     }
                 }
             }
         },
-        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.UploadInfo": {
+        "github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.UploadInfo": {
             "type": "object",
             "properties": {
                 "expires_at": {
@@ -5238,6 +5238,12 @@
                 "longitude": {
                     "type": "number"
                 },
+                "menu_images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "name": {
                     "type": "string",
                     "maxLength": 255
@@ -5325,6 +5331,12 @@
                 },
                 "longitude": {
                     "type": "number"
+                },
+                "menu_images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string",

--- a/apps/core/docs/swagger.yaml
+++ b/apps/core/docs/swagger.yaml
@@ -1,27 +1,27 @@
 basePath: /api/v1
 definitions:
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.FileRequest:
+  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.FileRequest:
     properties:
       content_type:
         type: string
       filename:
         type: string
     type: object
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLRequest:
+  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLRequest:
     properties:
       files:
         items:
-          $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.FileRequest'
+          $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.FileRequest'
         type: array
     type: object
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLResponse:
+  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLResponse:
     properties:
       uploads:
         items:
-          $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.UploadInfo'
+          $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.UploadInfo'
         type: array
     type: object
-  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.UploadInfo:
+  github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.UploadInfo:
     properties:
       expires_at:
         type: string
@@ -173,6 +173,10 @@ definitions:
         type: number
       longitude:
         type: number
+      menu_images:
+        items:
+          type: string
+        type: array
       name:
         maxLength: 255
         type: string
@@ -235,6 +239,10 @@ definitions:
         type: number
       longitude:
         type: number
+      menu_images:
+        items:
+          type: string
+        type: array
       name:
         maxLength: 255
         type: string
@@ -1208,14 +1216,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLRequest'
+          $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_service.PresignedURLResponse'
+            $ref: '#/definitions/github_com_RevieU-Corp_revieu-backend_apps_core_internal_domain_media_dto.PresignedURLResponse'
         "400":
           description: Bad Request
           schema:

--- a/apps/core/internal/domain/media/dto/media.go
+++ b/apps/core/internal/domain/media/dto/media.go
@@ -1,0 +1,23 @@
+package dto
+
+import "time"
+
+type FileRequest struct {
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+}
+
+type PresignedURLRequest struct {
+	Files []FileRequest `json:"files"`
+}
+
+type UploadInfo struct {
+	ID        string    `json:"id"`
+	UploadURL string    `json:"upload_url"`
+	FileURL   string    `json:"file_url"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type PresignedURLResponse struct {
+	Uploads []UploadInfo `json:"uploads"`
+}

--- a/apps/core/internal/domain/media/handler/media.go
+++ b/apps/core/internal/domain/media/handler/media.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/media/dto"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/media/service"
 	"github.com/gin-gonic/gin"
 )
@@ -68,8 +69,8 @@ func (h *MediaHandler) Analyze(c *gin.Context) {
 // @Tags media
 // @Accept json
 // @Produce json
-// @Param request body service.PresignedURLRequest true "Files to upload"
-// @Success 200 {object} service.PresignedURLResponse
+// @Param request body dto.PresignedURLRequest true "Files to upload"
+// @Success 200 {object} dto.PresignedURLResponse
 // @Failure 400 {object} map[string]string
 // @Failure 401 {object} map[string]string
 // @Failure 500 {object} map[string]string
@@ -81,7 +82,7 @@ func (h *MediaHandler) CreatePresignedURLs(c *gin.Context) {
 		return
 	}
 
-	var req service.PresignedURLRequest
+	var req dto.PresignedURLRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 		return

--- a/apps/core/internal/domain/media/service/service.go
+++ b/apps/core/internal/domain/media/service/service.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/domain/media/dto"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/internal/model"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/pkg/database"
 	"github.com/RevieU-Corp/revieu-backend/apps/core/pkg/storage"
@@ -38,37 +39,17 @@ func NewMediaService(db *gorm.DB, r2Client *storage.R2Client) *MediaService {
 	return &MediaService{db: db, r2Client: r2Client}
 }
 
-type FileRequest struct {
-	Filename    string `json:"filename"`
-	ContentType string `json:"content_type"`
-}
-
-type PresignedURLRequest struct {
-	Files []FileRequest `json:"files"`
-}
-
-type UploadInfo struct {
-	ID        string    `json:"id"`
-	UploadURL string    `json:"upload_url"`
-	FileURL   string    `json:"file_url"`
-	ExpiresAt time.Time `json:"expires_at"`
-}
-
-type PresignedURLResponse struct {
-	Uploads []UploadInfo `json:"uploads"`
-}
-
-func (s *MediaService) CreatePresignedURLs(ctx context.Context, userID int64, req *PresignedURLRequest) (*PresignedURLResponse, error) {
+func (s *MediaService) CreatePresignedURLs(ctx context.Context, userID int64, req *dto.PresignedURLRequest) (*dto.PresignedURLResponse, error) {
 	if len(req.Files) > 10 {
 		return nil, ErrTooManyFiles
 	}
 
 	if len(req.Files) == 0 {
-		return &PresignedURLResponse{Uploads: []UploadInfo{}}, nil
+		return &dto.PresignedURLResponse{Uploads: []dto.UploadInfo{}}, nil
 	}
 
-	response := &PresignedURLResponse{
-		Uploads: make([]UploadInfo, 0, len(req.Files)),
+	response := &dto.PresignedURLResponse{
+		Uploads: make([]dto.UploadInfo, 0, len(req.Files)),
 	}
 
 	now := time.Now()
@@ -101,7 +82,7 @@ func (s *MediaService) CreatePresignedURLs(ctx context.Context, userID int64, re
 			return nil, fmt.Errorf("failed to save upload record: %w", err)
 		}
 
-		response.Uploads = append(response.Uploads, UploadInfo{
+		response.Uploads = append(response.Uploads, dto.UploadInfo{
 			ID:        fileUUID,
 			UploadURL: result.UploadURL,
 			FileURL:   result.FileURL,

--- a/apps/core/internal/domain/store/dto/store.go
+++ b/apps/core/internal/domain/store/dto/store.go
@@ -15,6 +15,7 @@ type CreateStoreRequest struct {
 	Longitude     float64            `json:"longitude"`
 	CoverImageURL string             `json:"cover_image_url" binding:"max=255"`
 	Images        []string           `json:"images"`
+	MenuImages    []string           `json:"menu_images"`
 	Hours         []StoreHourRequest `json:"hours"`
 	CategoryIDs   []int64            `json:"category_ids"`
 }
@@ -34,6 +35,7 @@ type UpdateStoreRequest struct {
 	Longitude     *float64            `json:"longitude"`
 	CoverImageURL *string             `json:"cover_image_url" binding:"omitempty,max=255"`
 	Images        *[]string           `json:"images"`
+	MenuImages    *[]string           `json:"menu_images"`
 	Hours         *[]StoreHourRequest `json:"hours"`
 	CategoryIDs   *[]int64            `json:"category_ids"`
 }

--- a/apps/core/internal/domain/store/service/service.go
+++ b/apps/core/internal/domain/store/service/service.go
@@ -71,6 +71,10 @@ func (s *StoreService) Create(ctx context.Context, userID int64, req dto.CreateS
 	if err != nil {
 		return nil, err
 	}
+	menuImagesRaw, err := json.Marshal(req.MenuImages)
+	if err != nil {
+		return nil, err
+	}
 
 	storeName := req.Name
 	if storeName == "" {
@@ -98,6 +102,7 @@ func (s *StoreService) Create(ctx context.Context, userID int64, req dto.CreateS
 		Longitude:     req.Longitude,
 		CoverImageURL: req.CoverImageURL,
 		Images:        string(imagesRaw),
+		MenuImages:    string(menuImagesRaw),
 		Status:        StoreStatusDraft,
 	}
 
@@ -437,6 +442,13 @@ func (s *StoreService) Update(ctx context.Context, userID, storeID int64, req dt
 			return nil, err
 		}
 		updates["images"] = string(imagesRaw)
+	}
+	if req.MenuImages != nil {
+		menuImagesRaw, err := json.Marshal(*req.MenuImages)
+		if err != nil {
+			return nil, err
+		}
+		updates["menu_images"] = string(menuImagesRaw)
 	}
 
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {

--- a/apps/core/internal/domain/store/service/service_test.go
+++ b/apps/core/internal/domain/store/service/service_test.go
@@ -110,6 +110,82 @@ func TestStoreServiceCreate(t *testing.T) {
 	}
 }
 
+func TestStoreServiceMenuImages(t *testing.T) {
+	db := setupStoreTestDB(t)
+	svc := NewStoreService(db)
+
+	userID := int64(111)
+	if err := db.Create(&model.User{ID: userID, Role: "user", Status: 0}).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	merchant := model.Merchant{Name: "Menu Merchant", UserID: &userID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+
+	initialMenuImages := []string{
+		"https://cdn.test/menu-1.jpg",
+		"https://cdn.test/menu-2.jpg",
+	}
+	store, err := svc.Create(context.Background(), userID, dto.CreateStoreRequest{
+		Name:       "Menu Store",
+		MenuImages: initialMenuImages,
+	})
+	if err != nil {
+		t.Fatalf("create returned error: %v", err)
+	}
+
+	var createdMenuImages []string
+	if err := json.Unmarshal([]byte(store.MenuImages), &createdMenuImages); err != nil {
+		t.Fatalf("failed to unmarshal created menu images: %v", err)
+	}
+	if len(createdMenuImages) != len(initialMenuImages) {
+		t.Fatalf("unexpected created menu images length: got %d want %d", len(createdMenuImages), len(initialMenuImages))
+	}
+	for i := range initialMenuImages {
+		if createdMenuImages[i] != initialMenuImages[i] {
+			t.Fatalf("unexpected created menu image %d: got %q want %q", i, createdMenuImages[i], initialMenuImages[i])
+		}
+	}
+
+	if err := db.Model(&model.Store{}).Where("id = ?", store.ID).Update("status", StoreStatusPublished).Error; err != nil {
+		t.Fatalf("failed to publish store for detail lookup: %v", err)
+	}
+
+	detail, err := svc.DetailPublished(context.Background(), store.ID)
+	if err != nil {
+		t.Fatalf("detail returned error: %v", err)
+	}
+	if detail.MenuImages != store.MenuImages {
+		t.Fatalf("unexpected detail menu images: got %q want %q", detail.MenuImages, store.MenuImages)
+	}
+
+	replacementMenuImages := []string{
+		"https://cdn.test/menu-a.jpg",
+		"https://cdn.test/menu-b.jpg",
+		"https://cdn.test/menu-c.jpg",
+	}
+	updated, err := svc.Update(context.Background(), userID, store.ID, dto.UpdateStoreRequest{
+		MenuImages: &replacementMenuImages,
+	})
+	if err != nil {
+		t.Fatalf("update returned error: %v", err)
+	}
+
+	var updatedMenuImages []string
+	if err := json.Unmarshal([]byte(updated.MenuImages), &updatedMenuImages); err != nil {
+		t.Fatalf("failed to unmarshal updated menu images: %v", err)
+	}
+	if len(updatedMenuImages) != len(replacementMenuImages) {
+		t.Fatalf("unexpected updated menu images length: got %d want %d", len(updatedMenuImages), len(replacementMenuImages))
+	}
+	for i := range replacementMenuImages {
+		if updatedMenuImages[i] != replacementMenuImages[i] {
+			t.Fatalf("unexpected updated menu image %d: got %q want %q", i, updatedMenuImages[i], replacementMenuImages[i])
+		}
+	}
+}
+
 func TestStoreServiceCreateAutoCreatesMerchantPlaceholder(t *testing.T) {
 	db := setupStoreTestDB(t)
 	svc := NewStoreService(db)

--- a/apps/core/internal/model/store.go
+++ b/apps/core/internal/model/store.go
@@ -22,6 +22,7 @@ type Store struct {
 	Longitude     float64        `json:"longitude"`
 	CoverImageURL string         `gorm:"type:varchar(255)" json:"cover_image_url"`
 	Images        string         `gorm:"type:jsonb;default:'[]'" json:"images"`
+	MenuImages    string         `gorm:"type:jsonb;default:'[]'" json:"menu_images"`
 	AvgRating     float32        `gorm:"default:0" json:"avg_rating"`
 	ReviewCount   int            `gorm:"default:0" json:"review_count"`
 	FollowerCount int            `gorm:"default:0" json:"follower_count"`

--- a/apps/core/internal/router/openapi_v1_test.go
+++ b/apps/core/internal/router/openapi_v1_test.go
@@ -1635,6 +1635,65 @@ func TestStoreUpdateOwnStore(t *testing.T) {
 	}
 }
 
+func TestStoreMenuImages(t *testing.T) {
+	r, tok := setupAPITest(t)
+	db := database.DB
+
+	var ownerAuth model.UserAuth
+	if err := db.Where("identifier = ?", "user@example.com").First(&ownerAuth).Error; err != nil {
+		t.Fatalf("failed to load owner auth: %v", err)
+	}
+	ownerID := ownerAuth.UserID
+
+	merchant := model.Merchant{Name: "Owner Merchant", UserID: &ownerID}
+	if err := db.Create(&merchant).Error; err != nil {
+		t.Fatalf("failed to create merchant: %v", err)
+	}
+	store := model.Store{MerchantID: merchant.ID, Name: "Menu Store", Status: 1}
+	if err := db.Create(&store).Error; err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	body := strings.NewReader(`{"menu_images":["https://cdn.revieu.com/menu-1.jpg","https://cdn.revieu.com/menu-2.jpg"]}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/merchant/stores/%d", store.ID), body)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected patch 200, got %d", w.Code)
+	}
+
+	var patchResp struct {
+		Data model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &patchResp); err != nil {
+		t.Fatalf("failed to decode patch response: %v", err)
+	}
+	if patchResp.Data.MenuImages != `["https://cdn.revieu.com/menu-1.jpg","https://cdn.revieu.com/menu-2.jpg"]` {
+		t.Fatalf("unexpected patched menu images: %q", patchResp.Data.MenuImages)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/stores/%d", store.ID), nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected detail 200, got %d", w.Code)
+	}
+
+	var detailResp struct {
+		Data model.Store `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &detailResp); err != nil {
+		t.Fatalf("failed to decode detail response: %v", err)
+	}
+	if detailResp.Data.MenuImages != `["https://cdn.revieu.com/menu-1.jpg","https://cdn.revieu.com/menu-2.jpg"]` {
+		t.Fatalf("unexpected detail menu images: %q", detailResp.Data.MenuImages)
+	}
+}
+
 func TestStoreUpdateForbiddenForNonOwner(t *testing.T) {
 	r, _ := setupAPITest(t)
 	db := database.DB

--- a/apps/core/migrations/00004_add_store_menu_images.sql
+++ b/apps/core/migrations/00004_add_store_menu_images.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+ALTER TABLE stores
+ADD COLUMN IF NOT EXISTS menu_images JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- +goose Down
+
+ALTER TABLE stores
+DROP COLUMN IF EXISTS menu_images;


### PR DESCRIPTION
## Summary
- add store.menu_images schema support to the store model and DTOs
- persist menu_images on merchant store create and update flows
- add a Goose migration and backend tests for the new store menu image field

## Test Plan
- go test ./internal/domain/store/...
- go test ./internal/router -run TestStoreMenuImages -v

Closes #190