### PR TITLE
fix(voucher): add DELETE /vouchers/:id endpoint for customers

### DIFF
--- a/apps/core/internal/domain/voucher/handler/voucher.go
+++ b/apps/core/internal/domain/voucher/handler/voucher.go
@@ -176,6 +176,40 @@ func (h *VoucherHandler) UpdateStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{})
 }
 
+// DeleteVoucher godoc
+// @Summary Delete voucher
+// @Description Deletes a voucher owned by the authenticated user
+// @Tags voucher
+// @Produce json
+// @Param id path int true "Voucher ID"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Security BearerAuth
+// @Router /vouchers/{id} [delete]
+func (h *VoucherHandler) Delete(c *gin.Context) {
+	userID := c.GetInt64("user_id")
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.svc.DeleteForUser(c.Request.Context(), userID, id); err != nil {
+		if errors.Is(err, service.ErrVoucherNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete voucher"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
 // ShareVoucherEmail godoc
 // @Summary Share voucher via email
 // @Description Sends voucher share email

--- a/apps/core/internal/domain/voucher/routes.go
+++ b/apps/core/internal/domain/voucher/routes.go
@@ -19,6 +19,7 @@ func RegisterRoutes(r *gin.RouterGroup, cfg *config.Config) {
 		vouchers.GET("", h.List)
 		vouchers.GET("/:id", h.Detail)
 		vouchers.GET("/code/:code", h.ByCode)
+		vouchers.DELETE("/:id", h.Delete)
 		vouchers.PATCH("/:id/use", h.Use)
 		vouchers.PATCH("/:id/status", h.UpdateStatus)
 		vouchers.POST("/share/email", h.ShareEmail)

--- a/apps/core/internal/domain/voucher/service/service.go
+++ b/apps/core/internal/domain/voucher/service/service.go
@@ -129,6 +129,17 @@ func (s *VoucherService) UpdateStatus(ctx context.Context, id int64, status stri
 	return s.db.WithContext(ctx).Model(&model.Voucher{}).Where("id = ?", id).UpdateColumn("status", status).Error
 }
 
+func (s *VoucherService) DeleteForUser(ctx context.Context, userID, voucherID int64) error {
+	var v model.Voucher
+	if err := s.db.WithContext(ctx).Where("id = ? AND user_id = ?", voucherID, userID).First(&v).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrVoucherNotFound
+		}
+		return err
+	}
+	return s.db.WithContext(ctx).Delete(&v).Error
+}
+
 func (s *VoucherService) PreviewRedeemByToken(ctx context.Context, merchantUserID int64, scanToken string) (*RedeemPreview, error) {
 	var merchant model.Merchant
 	if err := s.db.WithContext(ctx).Where("user_id = ?", merchantUserID).First(&merchant).Error; err != nil {


### PR DESCRIPTION
## Summary
- Add `DELETE /vouchers/:id` endpoint so customers can remove vouchers from their rewards wallet
- Service layer validates ownership (`user_id` check) before deleting
- Fixes frontend profile "My Rewards" delete coupon functionality

## Test plan
- [ ] Authenticated user can delete their own voucher via `DELETE /vouchers/:id`
- [ ] Returns 404 if voucher doesn't belong to the user
- [ ] Returns 401 if not authenticated
- [ ] Frontend profile "My Rewards" coupon card X button removes the card after delete

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)